### PR TITLE
zsh: join shorthand and longhand flags to single group

### DIFF
--- a/internal/shell/zsh/action.go
+++ b/internal/shell/zsh/action.go
@@ -47,6 +47,12 @@ func quoteValue(s string) string {
 
 // ActionRawValues formats values for zsh
 func ActionRawValues(currentWord string, meta common.Meta, values common.RawValues) string {
+	for index, value := range values {
+		switch value.Tag {
+		case "shorthand flags", "longhand flags":
+			values[index].Tag = "flags" // join to single tag group for classic zsh side-by-side view
+		}
+	}
 
 	tagGroup := make([]string, 0)
 	values.EachTag(func(tag string, values common.RawValues) {


### PR DESCRIPTION
restores the classic side-by-side view which got lost due to the refined tags
