### PR TITLE
fix: xonsh: Refactor space appending logic in action.go

### DIFF
--- a/internal/shell/xonsh/action.go
+++ b/internal/shell/xonsh/action.go
@@ -27,6 +27,8 @@ func ActionRawValues(currentWord string, meta common.Meta, values common.RawValu
 	for index, val := range values {
 		val.Value = sanitizer.Replace(val.Value)
 
+		appendSpace := !meta.Nospace.Matches(val.Value)
+
 		if strings.ContainsAny(val.Value, ` ()[]{}*$?\"|<>&;#`+"`") {
 			if strings.Contains(val.Value, `\`) {
 				val.Value = fmt.Sprintf("r'%v'", val.Value) // backslash needs raw string
@@ -35,7 +37,7 @@ func ActionRawValues(currentWord string, meta common.Meta, values common.RawValu
 			}
 		}
 
-		if !meta.Nospace.Matches(val.Value) {
+		if appendSpace {
 			val.Value = val.Value + " "
 		}
 


### PR DESCRIPTION
Hi! I've got the issue request from xonsh shell user but I see that the issue is on carapace side.

### Before

```xsh
exec($(carapace _carapace xonsh))
cd /tmp
mkdir -p 'foo bar/1/2'
ls foo<Tab>  # carapace
ls 'foo bar' <cursor>  # space after completion and next Tab is not working to go to subdirectory 🔴 
```

### After

```xsh
ls foo<Tab>  # carapace
ls 'foo bar'<cursor>  #  no space after completion and next Tab is working to go to dubdirectory 🟢 
ls 'foo bar/1'
```

### Fix

Decide whether a trailing space is wanted BEFORE wrapping the value in quotes. Nospace is a SuffixMatcher and inspects the last rune of the value (e.g. "/" for directories, "=" for flags expecting a value). If we ran this check after quoting, the value would end with "'" and the match would always fail, causing a trailing space to be appended for paths like "foo bar/" -- the cursor would land after the space and tab completion of the next path part would be impossible.