### PR TITLE
Fix zsh value escaping for descriptions

### DIFF
--- a/internal/shell/zsh/action.go
+++ b/internal/shell/zsh/action.go
@@ -57,6 +57,10 @@ var describeReplacer = strings.NewReplacer(
 	`:`, `\:`,
 )
 
+var describeValueReplacer = strings.NewReplacer(
+	`:`, `\:`,
+)
+
 func quoteValue(s string) string {
 	if strings.HasPrefix(s, "~/") || NamedDirectories.Matches(s) {
 		return "~" + defaultReplacer.Replace(strings.TrimPrefix(s, "~")) // assume file path expansion
@@ -119,21 +123,21 @@ func ActionRawValues(currentWord string, meta common.Meta, values common.RawValu
 			switch state {
 			case QUOTING_ESCAPING_STATE:
 				value = quotingEscapingReplacer.Replace(value)
-				value = describeReplacer.Replace(value)
+				value = describeValueReplacer.Replace(value)
 				value = value + `"`
 			case QUOTING_STATE:
 				value = quotingReplacer.Replace(value)
-				value = describeReplacer.Replace(value)
+				value = describeValueReplacer.Replace(value)
 				value = value + `'`
 			case FULL_QUOTING_ESCAPING_STATE:
 				value = quotingEscapingReplacer.Replace(value)
-				value = describeReplacer.Replace(value)
+				value = describeValueReplacer.Replace(value)
 			case FULL_QUOTING_STATE:
 				value = quotingReplacer.Replace(value)
-				value = describeReplacer.Replace(value)
+				value = describeValueReplacer.Replace(value)
 			default:
 				value = quoteValue(value)
-				value = describeReplacer.Replace(value)
+				value = describeValueReplacer.Replace(value)
 			}
 
 			if !meta.Nospace.Matches(val.Value) {

--- a/internal/shell/zsh/action_test.go
+++ b/internal/shell/zsh/action_test.go
@@ -1,0 +1,28 @@
+package zsh
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/carapace-sh/carapace/internal/common"
+)
+
+func TestActionRawValuesEscapesSpecialCharactersOnce(t *testing.T) {
+	output := ActionRawValues("", common.Meta{}, common.RawValues{
+		{Value: "Test2&Testaaa.txt", Display: "Test2&Testaaa.txt"},
+		{Value: "spaceT TT.x", Display: "spaceT TT.x"},
+	})
+
+	if !strings.Contains(output, `Test2\&Testaaa.txt`) {
+		t.Fatalf("expected ampersand to be escaped once, got %q", output)
+	}
+	if strings.Contains(output, `Test2\\&Testaaa.txt`) {
+		t.Fatalf("expected ampersand not to be double-escaped, got %q", output)
+	}
+	if !strings.Contains(output, `spaceT\ TT.x`) {
+		t.Fatalf("expected space to be escaped once, got %q", output)
+	}
+	if strings.Contains(output, `spaceT\\ TT.x`) {
+		t.Fatalf("expected space not to be double-escaped, got %q", output)
+	}
+}


### PR DESCRIPTION
Refs #1207

## Summary
- avoid re-escaping already shell-escaped completion values when formatting zsh `_describe` output
- keep colon escaping for `_describe` values while leaving backslash escaping from the shell-specific value quoting intact
- add a regression test for file names containing spaces and `&`

## Validation
- `go test ./internal/shell/zsh`
- `go test ./internal/shell/...`
- `go test ./...`
- `git diff --check`
