### PR TITLE
Add CARAPACE_DESCRIPTION_LENGTH

### DIFF
--- a/internal/common/value.go
+++ b/internal/common/value.go
@@ -2,7 +2,9 @@
 package common
 
 import (
+	"os"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/carapace-sh/carapace/pkg/match"
@@ -25,13 +27,24 @@ type RawValue struct {
 
 // TrimmedDescription returns the trimmed description.
 func (r RawValue) TrimmedDescription() string {
-	maxLength := 80
+	maxLength := descriptionLength()
 	description := strings.SplitN(r.Description, "\n", 2)[0]
 	description = strings.TrimSpace(description)
-	if len([]rune(description)) > maxLength {
-		description = string([]rune(description)[:maxLength-3]) + "..."
+	runes := []rune(description)
+	if len(runes) > maxLength {
+		if maxLength <= 3 {
+			return string(runes[:maxLength])
+		}
+		description = string(runes[:maxLength-3]) + "..."
 	}
 	return description
+}
+
+func descriptionLength() int {
+	if parsed, err := strconv.Atoi(os.Getenv("CARAPACE_DESCRIPTION_LENGTH")); err == nil && parsed > 0 {
+		return parsed
+	}
+	return 80
 }
 
 // RawValues is an alias for []RawValue.

--- a/internal/common/value.go
+++ b/internal/common/value.go
@@ -2,11 +2,10 @@
 package common
 
 import (
-	"os"
 	"sort"
-	"strconv"
 	"strings"
 
+	"github.com/carapace-sh/carapace/internal/env"
 	"github.com/carapace-sh/carapace/pkg/match"
 	"github.com/carapace-sh/carapace/pkg/style"
 )
@@ -27,7 +26,7 @@ type RawValue struct {
 
 // TrimmedDescription returns the trimmed description.
 func (r RawValue) TrimmedDescription() string {
-	maxLength := descriptionLength()
+	maxLength := env.DescriptionLength()
 	description := strings.SplitN(r.Description, "\n", 2)[0]
 	description = strings.TrimSpace(description)
 	runes := []rune(description)
@@ -38,13 +37,6 @@ func (r RawValue) TrimmedDescription() string {
 		description = string(runes[:maxLength-3]) + "..."
 	}
 	return description
-}
-
-func descriptionLength() int {
-	if parsed, err := strconv.Atoi(os.Getenv("CARAPACE_DESCRIPTION_LENGTH")); err == nil && parsed > 0 {
-		return parsed
-	}
-	return 80
 }
 
 // RawValues is an alias for []RawValue.

--- a/internal/common/value_test.go
+++ b/internal/common/value_test.go
@@ -14,6 +14,39 @@ func TestTrimmedDescription(t *testing.T) {
 	}
 }
 
+func TestTrimmedDescriptionLength(t *testing.T) {
+	t.Setenv("CARAPACE_DESCRIPTION_LENGTH", "20")
+
+	r := RawValue{
+		Description: "1234567890123456789012345",
+	}
+	if r.TrimmedDescription() != "12345678901234567..." {
+		t.Error("description should use CARAPACE_DESCRIPTION_LENGTH")
+	}
+}
+
+func TestTrimmedDescriptionLengthInvalid(t *testing.T) {
+	t.Setenv("CARAPACE_DESCRIPTION_LENGTH", "invalid")
+
+	r := RawValue{
+		Description: "123456789012345678901234567890123456789012345678901234567890123456789012345678901",
+	}
+	if r.TrimmedDescription() != "12345678901234567890123456789012345678901234567890123456789012345678901234567..." {
+		t.Error("invalid CARAPACE_DESCRIPTION_LENGTH should keep default length")
+	}
+}
+
+func TestTrimmedDescriptionShortLength(t *testing.T) {
+	t.Setenv("CARAPACE_DESCRIPTION_LENGTH", "3")
+
+	r := RawValue{
+		Description: "1234567890",
+	}
+	if r.TrimmedDescription() != "123" {
+		t.Error("short CARAPACE_DESCRIPTION_LENGTH should not exceed configured length")
+	}
+}
+
 func TestRawValuesFrom(t *testing.T) {
 	v := RawValuesFrom("first", "second")
 	if !equalRawValues(v[0], RawValue{

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -7,26 +7,27 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/carapace-sh/carapace/internal/common"
+	"github.com/carapace-sh/carapace/internal/mock"
 )
 
 const (
-	CARAPACE_COLOR         = "CARAPACE_COLOR"         // enable color
-	CARAPACE_COMPLINE      = "CARAPACE_COMPLINE"      // TODO
-	CARAPACE_COVERDIR      = "CARAPACE_COVERDIR"      // coverage directory for sandbox tests
-	CARAPACE_EXPERIMENTAL  = "CARAPACE_EXPERIMENTAL"  // enable experimental features
-	CARAPACE_HIDDEN        = "CARAPACE_HIDDEN"        // show hidden commands/flags
-	CARAPACE_LENIENT       = "CARAPACE_LENIENT"       // allow unknown flags
-	CARAPACE_LOG           = "CARAPACE_LOG"           // enable logging
-	CARAPACE_MATCH         = "CARAPACE_MATCH"         // match case insensitive
-	CARAPACE_MERGEFLAGS    = "CARAPACE_MERGEFLAGS"    // merge flags to single tag group
-	CARAPACE_NOSPACE       = "CARAPACE_NOSPACE"       // nospace suffixes
-	CARAPACE_SANDBOX       = "CARAPACE_SANDBOX"       // mock context for sandbox tests
-	CARAPACE_TOOLTIP       = "CARAPACE_TOOLTIP"       // enable tooltip style
-	CARAPACE_UNFILTERED    = "CARAPACE_UNFILTERED"    // skip the final filtering step
-	CARAPACE_ZSH_HASH_DIRS = "CARAPACE_ZSH_HASH_DIRS" // zsh hash directories
-	CLICOLOR               = "CLICOLOR"               // disable color
-	NO_COLOR               = "NO_COLOR"               // disable color
+	CARAPACE_COLOR              = "CARAPACE_COLOR"              // enable color
+	CARAPACE_COMPLINE           = "CARAPACE_COMPLINE"           // TODO
+	CARAPACE_COVERDIR           = "CARAPACE_COVERDIR"           // coverage directory for sandbox tests
+	CARAPACE_DESCRIPTION_LENGTH = "CARAPACE_DESCRIPTION_LENGTH" // maximum description length
+	CARAPACE_EXPERIMENTAL       = "CARAPACE_EXPERIMENTAL"       // enable experimental features
+	CARAPACE_HIDDEN             = "CARAPACE_HIDDEN"             // show hidden commands/flags
+	CARAPACE_LENIENT            = "CARAPACE_LENIENT"            // allow unknown flags
+	CARAPACE_LOG                = "CARAPACE_LOG"                // enable logging
+	CARAPACE_MATCH              = "CARAPACE_MATCH"              // match case insensitive
+	CARAPACE_MERGEFLAGS         = "CARAPACE_MERGEFLAGS"         // merge flags to single tag group
+	CARAPACE_NOSPACE            = "CARAPACE_NOSPACE"            // nospace suffixes
+	CARAPACE_SANDBOX            = "CARAPACE_SANDBOX"            // mock context for sandbox tests
+	CARAPACE_TOOLTIP            = "CARAPACE_TOOLTIP"            // enable tooltip style
+	CARAPACE_UNFILTERED         = "CARAPACE_UNFILTERED"         // skip the final filtering step
+	CARAPACE_ZSH_HASH_DIRS      = "CARAPACE_ZSH_HASH_DIRS"      // zsh hash directories
+	CLICOLOR                    = "CLICOLOR"                    // disable color
+	NO_COLOR                    = "NO_COLOR"                    // disable color
 )
 
 func ColorDisabled() bool {
@@ -48,7 +49,7 @@ func Hashdirs() string {
 	return os.Getenv(CARAPACE_ZSH_HASH_DIRS)
 }
 
-func Sandbox() (m *common.Mock, err error) {
+func Sandbox() (m *mock.Mock, err error) {
 	sandbox := os.Getenv(CARAPACE_SANDBOX)
 	if sandbox == "" || !isGoRun() {
 		return nil, errors.New("no sandbox")
@@ -125,4 +126,11 @@ func getBool(s string) bool {
 	default:
 		return false
 	}
+}
+
+func DescriptionLength() int {
+	if parsed, err := strconv.Atoi(os.Getenv(CARAPACE_DESCRIPTION_LENGTH)); err == nil && parsed > 0 {
+		return parsed
+	}
+	return 80
 }

--- a/internal/mock/mock.go
+++ b/internal/mock/mock.go
@@ -1,4 +1,4 @@
-package common
+package mock
 
 import (
 	"fmt"

--- a/pkg/sandbox/sandbox.go
+++ b/pkg/sandbox/sandbox.go
@@ -13,6 +13,7 @@ import (
 	"github.com/carapace-sh/carapace/internal/common"
 	"github.com/carapace-sh/carapace/internal/env"
 	"github.com/carapace-sh/carapace/internal/export"
+	"github.com/carapace-sh/carapace/internal/mock"
 	"github.com/carapace-sh/carapace/pkg/assert"
 	"github.com/spf13/cobra"
 )
@@ -22,7 +23,7 @@ type Sandbox struct {
 	cmdF func() *cobra.Command
 	env  map[string]string
 	keep bool
-	mock *common.Mock
+	mock *mock.Mock
 }
 
 func newSandbox(t *testing.T, f func() *cobra.Command) Sandbox {
@@ -30,7 +31,7 @@ func newSandbox(t *testing.T, f func() *cobra.Command) Sandbox {
 		t:    t,
 		cmdF: f,
 		env:  make(map[string]string),
-		mock: common.NewMock(t),
+		mock: mock.NewMock(t),
 	}
 }
 


### PR DESCRIPTION
Adds `CARAPACE_DESCRIPTION_LENGTH` for the existing shell export description trimming.

The default stays at 80 when the env var is unset, invalid, or non-positive. Small positive values are handled without returning a string longer than the configured limit.

Tested with:

```sh
go test ./internal/common
```

Fixes #1129