### PR TITLE
Show current shorthand flag completion

### DIFF
--- a/carapace_test.go
+++ b/carapace_test.go
@@ -231,7 +231,7 @@ func TestComplete(t *testing.T) {
 	cmd.Flags().BoolP("a", "1", false, "")
 	cmd.Flags().BoolP("b", "2", false, "")
 
-	if s, err := complete(cmd, []string{"elvish", "_", "test", "-1"}); err != nil || s != `{"Usage":"","Messages":[],"DescriptionStyle":"dim","Candidates":[{"Value":"-12","Display":"2","Description":"","CodeSuffix":"","Style":"default"},{"Value":"-1h","Display":"h","Description":"help for test","CodeSuffix":"","Style":"default"}]}` {
+	if s, err := complete(cmd, []string{"elvish", "_", "test", "-1"}); err != nil || s != `{"Usage":"","Messages":[],"DescriptionStyle":"dim","Candidates":[{"Value":"-1","Display":"-1","Description":"","CodeSuffix":" ","Style":"default"},{"Value":"-12","Display":"2","Description":"","CodeSuffix":"","Style":"default"},{"Value":"-1h","Display":"h","Description":"help for test","CodeSuffix":"","Style":"default"}]}` {
 		t.Error(s)
 	}
 }

--- a/defaultActions_test.go
+++ b/defaultActions_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/carapace-sh/carapace/internal/common"
 	"github.com/carapace-sh/carapace/pkg/assert"
-	"github.com/carapace-sh/carapace/pkg/uid"
 	"github.com/spf13/cobra"
 )
 
@@ -41,19 +41,15 @@ func TestActionFlags(t *testing.T) {
 
 	cmd.Flag("alpha").Changed = true
 	a := actionFlags(cmd).Invoke(Context{Value: "-a"})
+	expected := Action{rawValues: common.RawValues{
+		{Value: "-a", Display: "-a", Tag: "shorthand flags", Uid: "cmd://actionFlags?flag=alpha"},
+		{Value: "-ab", Display: "b", Tag: "shorthand flags", Uid: "cmd://actionFlags?flag=beta"},
+		{Value: "-ah", Display: "h", Description: "help for actionFlags", Tag: "shorthand flags", Uid: "cmd://actionFlags?flag=help"},
+	}}
+	expected.meta.Nospace.Add('b', 'h')
 	assert.Equal(
 		t,
-		ActionValuesDescribed(
-			"b", "",
-			"h", "help for actionFlags",
-		).Tag("shorthand flags").
-			NoSpace('b', 'h').
-			Invoke(Context{}).
-			Prefix("-a").
-			UidF(uid.Map(
-				"-ab", "cmd://actionFlags?flag=beta",
-				"-ah", "cmd://actionFlags?flag=help",
-			)),
+		expected.Invoke(Context{}),
 		a,
 	)
 }

--- a/example/cmd/chain_test.go
+++ b/example/cmd/chain_test.go
@@ -5,45 +5,50 @@ import (
 
 	"github.com/carapace-sh/carapace"
 	"github.com/carapace-sh/carapace/pkg/sandbox"
-	"github.com/carapace-sh/carapace/pkg/style"
 )
 
 func TestShorthandChain(t *testing.T) {
 	sandbox.Package(t, "github.com/carapace-sh/carapace/example")(func(s *sandbox.Sandbox) {
 		s.Run("chain", "-b").
-			Expect(carapace.ActionStyledValues(
-				"c", style.Default,
-				"o", style.Yellow,
-				"v", style.Blue,
-			).Prefix("-b").
-				NoSpace('c', 'o').
-				Tag("shorthand flags"))
+			Expect(carapace.ActionImport([]byte(`{
+  "nospace": "co",
+  "values": [
+    {"value": "-b", "display": "-b", "tag": "shorthand flags"},
+    {"value": "-bc", "display": "c", "tag": "shorthand flags"},
+    {"value": "-bo", "display": "o", "style": "yellow", "tag": "shorthand flags"},
+    {"value": "-bv", "display": "v", "style": "blue", "tag": "shorthand flags"}
+  ]
+}`)))
 
 		s.Run("chain", "-bc").
-			Expect(carapace.ActionStyledValues(
-				"c", style.Default,
-				"o", style.Yellow,
-				"v", style.Blue,
-			).Prefix("-bc").
-				NoSpace('c', 'o').
-				Tag("shorthand flags"))
+			Expect(carapace.ActionImport([]byte(`{
+  "nospace": "o",
+  "values": [
+    {"value": "-bc", "display": "-bc", "tag": "shorthand flags"},
+    {"value": "-bco", "display": "o", "style": "yellow", "tag": "shorthand flags"},
+    {"value": "-bcv", "display": "v", "style": "blue", "tag": "shorthand flags"}
+  ]
+}`)))
 
 		s.Run("chain", "-bcc").
-			Expect(carapace.ActionStyledValues(
-				"c", style.Default,
-				"o", style.Yellow,
-				"v", style.Blue,
-			).Prefix("-bcc").
-				NoSpace('c', 'o').
-				Tag("shorthand flags"))
+			Expect(carapace.ActionImport([]byte(`{
+  "nospace": "o",
+  "values": [
+    {"value": "-bcc", "display": "-bcc", "tag": "shorthand flags"},
+    {"value": "-bcco", "display": "o", "style": "yellow", "tag": "shorthand flags"},
+    {"value": "-bccv", "display": "v", "style": "blue", "tag": "shorthand flags"}
+  ]
+}`)))
 
 		s.Run("chain", "-bcco").
-			Expect(carapace.ActionStyledValues(
-				"c", style.Default,
-				"v", style.Blue,
-			).Prefix("-bcco").
-				NoSpace('c').
-				Tag("shorthand flags"))
+			Expect(carapace.ActionImport([]byte(`{
+  "nospace": "c",
+  "values": [
+    {"value": "-bcco", "display": "-bcco", "style": "yellow", "tag": "shorthand flags"},
+    {"value": "-bccoc", "display": "c", "tag": "shorthand flags"},
+    {"value": "-bccov", "display": "v", "style": "blue", "tag": "shorthand flags"}
+  ]
+}`)))
 
 		s.Run("chain", "-bcco", "").
 			Expect(carapace.ActionValues(
@@ -70,11 +75,12 @@ func TestShorthandChain(t *testing.T) {
 			).Prefix("-bccv="))
 
 		s.Run("chain", "-bccv", "val1", "-c").
-			Expect(carapace.ActionStyledValues(
-				"c", style.Default,
-				"o", style.Yellow,
-			).Prefix("-c").
-				NoSpace('c', 'o').
-				Tag("shorthand flags"))
+			Expect(carapace.ActionImport([]byte(`{
+  "nospace": "o",
+  "values": [
+    {"value": "-c", "display": "-c", "tag": "shorthand flags"},
+    {"value": "-co", "display": "o", "style": "yellow", "tag": "shorthand flags"}
+  ]
+}`)))
 	})
 }

--- a/internalActions.go
+++ b/internalActions.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/carapace-sh/carapace/internal/common"
 	"github.com/carapace-sh/carapace/internal/env"
 	"github.com/carapace-sh/carapace/internal/pflagfork"
 	"github.com/carapace-sh/carapace/pkg/style"
@@ -89,16 +90,21 @@ func actionFlags(cmd *cobra.Command) Action {
 
 		flagSet := pflagfork.FlagSet{FlagSet: cmd.Flags()}
 		isShorthandSeries := flagSet.IsShorthandSeries(c.Value)
+		currentShorthand := ""
+		if isShorthandSeries {
+			currentShorthand = currentShorthandFlag(c.Value)
+		}
 
 		nospace := make([]rune, 0)
 		batch := Batch()
 		flagSet.VisitAll(func(f *pflagfork.Flag) {
+			isCurrentShorthand := isShorthandSeries && f.Shorthand != "" && f.Shorthand == currentShorthand
 			switch {
 			case f.Hidden && env.Hidden() == env.HIDDEN_NONE:
 				return // skip hidden flags
 			case f.Deprecated != "":
 				return // skip deprecated flags
-			case f.Changed && !f.IsRepeatable():
+			case f.Changed && !f.IsRepeatable() && !isCurrentShorthand:
 				return // don't repeat flag
 			case flagSet.IsMutuallyExclusive(f.Flag):
 				return // skip flag of group already set
@@ -111,9 +117,12 @@ func actionFlags(cmd *cobra.Command) Action {
 							return // abort shorthand flag series if a previous one is not bool or count and requires an argument (no default value)
 						}
 					}
-					batch = append(batch, ActionStyledValuesDescribed(f.Shorthand, f.Usage, f.Style()).Tag("shorthand flags").
-						UidF(func(s string, uc uid.Context) (*url.URL, error) { return uid.Flag(cmd, f), nil }))
-					if f.IsOptarg() {
+					value, display := f.Shorthand, f.Shorthand
+					if isCurrentShorthand {
+						value, display = "", c.Value
+					}
+					batch = append(batch, actionShorthandFlag(cmd, f, value, display))
+					if f.IsOptarg() && value != "" {
 						nospace = append(nospace, []rune(f.Shorthand)[0])
 					}
 				}
@@ -142,6 +151,25 @@ func actionFlags(cmd *cobra.Command) Action {
 		}
 		return batch.ToA().MultiParts(".") // multiparts completion for flags grouped with `.`
 	})
+}
+
+func currentShorthandFlag(value string) string {
+	if runes := []rune(value); len(runes) > 1 {
+		return string(runes[len(runes)-1])
+	}
+	return ""
+}
+
+func actionShorthandFlag(cmd *cobra.Command, f *pflagfork.Flag, value string, display string) Action {
+	return ActionCallback(func(Context) Action {
+		return Action{rawValues: common.RawValues{{
+			Value:       value,
+			Display:     display,
+			Description: f.Usage,
+			Style:       f.Style(),
+		}}}
+	}).Tag("shorthand flags").
+		UidF(func(s string, uc uid.Context) (*url.URL, error) { return uid.Flag(cmd, f), nil })
 }
 
 func initHelpCompletion(cmd *cobra.Command) {


### PR DESCRIPTION
## Summary
- include the currently typed shorthand flag as a completion candidate for shorthand series
- use the current token as display text while inserting an empty suffix, so accepting it keeps the token unchanged
- update shorthand-chain and shell completion expectations

Closes carapace-sh/carapace-bin#3340.

## Tests
- env -u NO_COLOR TERM=xterm PATH=/tmp/codex-go-toolchain/go/bin:/home/ahmad/.local/bin:/home/ahmad/.codex/tmp/arg0/codex-arg0Tat2BO:/home/ahmad/.nvm/versions/node/v22.19.0/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/path:/home/ahmad/.nvm/versions/node/v22.19.0/bin:/home/ahmad/anaconda3/bin:/home/ahmad/anaconda3/condabin:/home/ahmad/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin go test ./...
- git diff --check