### PR TITLE
fix zsh special character escaping

### DIFF
--- a/internal/shell/zsh/action.go
+++ b/internal/shell/zsh/action.go
@@ -53,7 +53,6 @@ var defaultReplacer = strings.NewReplacer(
 
 // additional replacement for use with `_describe` in shell script
 var describeReplacer = strings.NewReplacer(
-	`\`, `\\`,
 	`:`, `\:`,
 )
 

--- a/internal/shell/zsh/action_test.go
+++ b/internal/shell/zsh/action_test.go
@@ -1,0 +1,64 @@
+package zsh
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/carapace-sh/carapace/internal/common"
+	"github.com/carapace-sh/carapace/internal/env"
+)
+
+func TestActionRawValuesEscapesDefaultStateOnce(t *testing.T) {
+	t.Setenv(env.CARAPACE_COMPLINE, "example ")
+
+	output := ActionRawValues("", common.Meta{}, common.RawValues{
+		{Value: "test/Test2&Testaaa.txt", Display: "test/Test2&Testaaa.txt"},
+		{Value: "spaceT TT.x", Display: "spaceT TT.x"},
+		{Value: "colon:value", Display: "colon:value"},
+		{Value: `back\slash`, Display: `back\slash`},
+	})
+
+	values := zshActionValues(t, output)
+	assertContains(t, values, `test/Test2\&Testaaa.txt `)
+	assertNotContains(t, values, `test/Test2\\&Testaaa.txt `)
+	assertContains(t, values, `spaceT\ TT.x `)
+	assertNotContains(t, values, `spaceT\\ TT.x `)
+	assertContains(t, values, `colon\:value `)
+	assertContains(t, values, `back\\slash `)
+}
+
+func zshActionValues(t *testing.T, output string) string {
+	t.Helper()
+
+	sections := strings.Split(output, "\001")
+	if len(sections) < 3 {
+		t.Fatalf("expected zsh action output to have at least 3 sections, got %d: %q", len(sections), output)
+	}
+
+	blocks := strings.Split(strings.TrimSuffix(sections[2], "\002"), "\002")
+	if len(blocks) == 0 {
+		t.Fatalf("expected zsh action output to have at least one tag block: %q", output)
+	}
+
+	fields := strings.Split(blocks[0], "\003")
+	if len(fields) != 3 {
+		t.Fatalf("expected zsh action tag block to have 3 fields, got %d: %q", len(fields), blocks[0])
+	}
+	return fields[2]
+}
+
+func assertContains(t *testing.T, s string, substr string) {
+	t.Helper()
+
+	if !strings.Contains(s, substr) {
+		t.Fatalf("expected %q to contain %q", s, substr)
+	}
+}
+
+func assertNotContains(t *testing.T, s string, substr string) {
+	t.Helper()
+
+	if strings.Contains(s, substr) {
+		t.Fatalf("expected %q not to contain %q", s, substr)
+	}
+}


### PR DESCRIPTION
Fixes #1207.

This keeps `_describe`'s colon escaping, but stops re-escaping backslashes after zsh-special characters have already been escaped by `quoteValue`. Values such as `Test2&Testaaa.txt` and `spaceT TT.x` now reach the zsh `_describe` values array with a single escaping backslash instead of a doubled one.

Validation:
- `go test ./internal/shell/zsh`
- `go test ./...` was also run on Windows, but unrelated existing Windows/path and fixture expectation failures remain outside this change area (`TestActionDirectories`, `TestActionFiles`, generated shell snippet fixture executable names, `TestContextAbs`, `pkg/uid/TestExecutable`).