### PR TITLE
[codex] add no prefix completion modifier

### DIFF
--- a/action.go
+++ b/action.go
@@ -230,6 +230,14 @@ func (a Action) NoSpace(suffixes ...rune) Action {
 	})
 }
 
+// NoPrefix prevents common prefix insertion where supported.
+func (a Action) NoPrefix() Action {
+	return ActionCallback(func(c Context) Action {
+		a.meta.NoPrefix = true
+		return a
+	})
+}
+
 // Prefix adds a prefix to values (only the ones inserted, not the display values).
 //
 //	carapace.ActionValues("melon", "drop", "fall").Prefix("water")

--- a/action_test.go
+++ b/action_test.go
@@ -84,6 +84,22 @@ func TestNoSpace(t *testing.T) {
 	}
 }
 
+func TestNoPrefix(t *testing.T) {
+	a := ActionCallback(func(c Context) Action {
+		return ActionValues().Invoke(c).Merge(
+			ActionCallback(func(c Context) Action {
+				return ActionValues("one", "two").NoPrefix()
+			}).Invoke(c)).
+			ToA()
+	})
+	if a.meta.NoPrefix {
+		t.Fatal("uninvoked action should not disable prefix insertion")
+	}
+	if !a.Invoke(Context{}).action.meta.NoPrefix {
+		t.Fatal("invoked action should disable prefix insertion")
+	}
+}
+
 func TestActionDirectories(t *testing.T) {
 	assert.Equal(t,
 		ActionStyledValues(

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -23,6 +23,7 @@
     - [MultiParts](./carapace/action/multiParts.md)
     - [MultiPartsP](./carapace/action/multiPartsP.md)
     - [NoSpace](./carapace/action/noSpace.md)
+    - [NoPrefix](./carapace/action/noPrefix.md)
     - [Prefix](./carapace/action/prefix.md)
     - [Retain](./carapace/action/retain.md)
     - [Shift](./carapace/action/shift.md)

--- a/docs/src/carapace/action/noPrefix.md
+++ b/docs/src/carapace/action/noPrefix.md
@@ -1,0 +1,13 @@
+# NoPrefix
+
+[`NoPrefix`] prevents common prefix insertion where supported.
+
+```go
+carapace.ActionValues(
+	"--",
+	"---",
+	"----",
+).NoPrefix()
+```
+
+[`NoPrefix`]: https://pkg.go.dev/github.com/carapace-sh/carapace#Action.NoPrefix

--- a/example/cmd/_test/zsh.sh
+++ b/example/cmd/_test/zsh.sh
@@ -13,8 +13,8 @@ function _example_completion {
     fi
   fi
 
-  local zstyle message data
-  IFS=$'\001' read -r -d '' zstyle message data <<<"${lines}"
+  local zstyle message noprefix data
+  IFS=$'\001' read -r -d '' zstyle message noprefix data <<<"${lines}"
   # shellcheck disable=SC2154
   zstyle ":completion:${curcontext}:*" list-colors "${zstyle}"
   zstyle ":completion:${curcontext}:*" group-name ''
@@ -29,7 +29,8 @@ function _example_completion {
   
     [[ ${#valuesArr[@]} -gt 1 ]] && _describe -t "${tag}" "${tag}" displaysArr valuesArr -Q -S ''
   done <<<"${data}"
+
+  [[ "${noprefix}" = "true" ]] && compstate[insert]=menu
 }
 compquote '' 2>/dev/null && _example_completion
 compdef _example_completion example
-

--- a/internal/common/meta.go
+++ b/internal/common/meta.go
@@ -2,6 +2,7 @@ package common
 
 type Meta struct {
 	Messages Messages      `json:"messages"`
+	NoPrefix bool          `json:"noprefix,omitempty"`
 	Nospace  SuffixMatcher `json:"nospace"`
 	Usage    string        `json:"usage"`
 	Queries  Queries       `json:"queries,omitempty"`
@@ -11,6 +12,7 @@ func (m *Meta) Merge(other Meta) {
 	if other.Usage != "" {
 		m.Usage = other.Usage
 	}
+	m.NoPrefix = m.NoPrefix || other.NoPrefix
 	m.Nospace.Merge(other.Nospace)
 	m.Messages.Merge(other.Messages)
 	m.Queries.Merge(other.Queries)

--- a/internal/shell/zsh/action.go
+++ b/internal/shell/zsh/action.go
@@ -158,5 +158,5 @@ func ActionRawValues(currentWord string, meta common.Meta, values common.RawValu
 		}
 		tagGroup = append(tagGroup, strings.Join([]string{tag, strings.Join(displays, "\n"), strings.Join(vals, "\n")}, "\003"))
 	})
-	return fmt.Sprintf("%v\001%v\001%v\001", zstyles{values}.Format(), message{meta}.Format(), strings.Join(tagGroup, "\002")+"\002")
+	return fmt.Sprintf("%v\001%v\001%v\001%v\001", zstyles{values}.Format(), message{meta}.Format(), meta.NoPrefix, strings.Join(tagGroup, "\002")+"\002")
 }

--- a/internal/shell/zsh/snippet.go
+++ b/internal/shell/zsh/snippet.go
@@ -25,8 +25,8 @@ function _%[1]v_completion {
     fi
   fi
 
-  local zstyle message data
-  IFS=$'\001' read -r -d '' zstyle message data <<<"${lines}"
+  local zstyle message noprefix data
+  IFS=$'\001' read -r -d '' zstyle message noprefix data <<<"${lines}"
   # shellcheck disable=SC2154
   zstyle ":completion:${curcontext}:*" list-colors "${zstyle}"
   zstyle ":completion:${curcontext}:*" group-name ''
@@ -41,8 +41,9 @@ function _%[1]v_completion {
   
     [[ ${#valuesArr[@]} -gt 1 ]] && _describe -t "${tag}" "${tag}" displaysArr valuesArr -Q -S ''
   done <<<"${data}"
+
+  [[ "${noprefix}" = "true" ]] && compstate[insert]=menu
 }
 compquote '' 2>/dev/null && _%[1]v_completion
-compdef _%[1]v_completion %[1]v
-`, cmd.Name(), uid.Executable())
+compdef _%[1]v_completion %[1]v`, cmd.Name(), uid.Executable())
 }


### PR DESCRIPTION
## Summary
- add `Action.NoPrefix()` to let actions opt out of common prefix insertion
- propagate the new meta flag through action merging/export
- honor the flag in the zsh snippet by starting menu completion instead of inserting the shared prefix
- document the new modifier and update the zsh snippet fixture

Fixes #1213

## Validation
- `gofmt -w internal/common/meta.go action.go internal/shell/zsh/action.go internal/shell/zsh/snippet.go action_test.go`
- `go test . -run TestNoPrefix`
- `go test ./example/cmd -run TestZsh`

Note: `go test ./...` was run, but the full suite fails in this environment due to broad pre-existing style/color fixture differences unrelated to this change.