### PR TITLE
fix(zsh): allow disabling common prefix insertion

### DIFF
--- a/carapace_test.go
+++ b/carapace_test.go
@@ -213,6 +213,8 @@ func TestSnippet(t *testing.T) {
 
 	if s, _ := Gen(cmd).Snippet("zsh"); !strings.Contains(s, "compdef") {
 		t.Error("zsh")
+	} else if !strings.Contains(s, "CARAPACE_ZSH_NO_COMMON_PREFIX") || !strings.Contains(s, "_describe -t") || !strings.Contains(s, `"${describeOptions[@]}"`) {
+		t.Error("zsh no common prefix option missing")
 	}
 
 	if _, err := Gen(cmd).Snippet("unknown"); err == nil {

--- a/example/cmd/_test/zsh.sh
+++ b/example/cmd/_test/zsh.sh
@@ -19,6 +19,8 @@ function _example_completion {
   zstyle ":completion:${curcontext}:*" list-colors "${zstyle}"
   zstyle ":completion:${curcontext}:*" group-name ''
   [ -z "$message" ] || _message -r "${message}"
+  local describeOptions
+  [ "${CARAPACE_ZSH_NO_COMMON_PREFIX}" = true ] || [ "${CARAPACE_ZSH_NO_COMMON_PREFIX}" = 1 ] && describeOptions=(-U)
   
   local block tag displays values displaysArr valuesArr
   while IFS=$'\002' read -r -d $'\002' block; do
@@ -27,9 +29,8 @@ function _example_completion {
     IFS=$'\n' read -r -d $'\004' -A displaysArr <<<"${displays}"$'\004'
     IFS=$'\n' read -r -d $'\004' -A valuesArr <<<"${values}"$'\004'
   
-    [[ ${#valuesArr[@]} -gt 1 ]] && _describe -t "${tag}" "${tag}" displaysArr valuesArr -Q -S ''
+    [[ ${#valuesArr[@]} -gt 1 ]] && _describe -t "${tag}" "${tag}" displaysArr valuesArr -Q -S '' "${describeOptions[@]}"
   done <<<"${data}"
 }
 compquote '' 2>/dev/null && _example_completion
 compdef _example_completion example
-

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -11,23 +11,24 @@ import (
 )
 
 const (
-	CARAPACE_COLOR              = "CARAPACE_COLOR"              // enable color
-	CARAPACE_COMPLINE           = "CARAPACE_COMPLINE"           // TODO
-	CARAPACE_COVERDIR           = "CARAPACE_COVERDIR"           // coverage directory for sandbox tests
-	CARAPACE_DESCRIPTION_LENGTH = "CARAPACE_DESCRIPTION_LENGTH" // maximum description length
-	CARAPACE_EXPERIMENTAL       = "CARAPACE_EXPERIMENTAL"       // enable experimental features
-	CARAPACE_HIDDEN             = "CARAPACE_HIDDEN"             // show hidden commands/flags
-	CARAPACE_LENIENT            = "CARAPACE_LENIENT"            // allow unknown flags
-	CARAPACE_LOG                = "CARAPACE_LOG"                // enable logging
-	CARAPACE_MATCH              = "CARAPACE_MATCH"              // match case insensitive
-	CARAPACE_MERGEFLAGS         = "CARAPACE_MERGEFLAGS"         // merge flags to single tag group
-	CARAPACE_NOSPACE            = "CARAPACE_NOSPACE"            // nospace suffixes
-	CARAPACE_SANDBOX            = "CARAPACE_SANDBOX"            // mock context for sandbox tests
-	CARAPACE_TOOLTIP            = "CARAPACE_TOOLTIP"            // enable tooltip style
-	CARAPACE_UNFILTERED         = "CARAPACE_UNFILTERED"         // skip the final filtering step
-	CARAPACE_ZSH_HASH_DIRS      = "CARAPACE_ZSH_HASH_DIRS"      // zsh hash directories
-	CLICOLOR                    = "CLICOLOR"                    // disable color
-	NO_COLOR                    = "NO_COLOR"                    // disable color
+	CARAPACE_COLOR                = "CARAPACE_COLOR"                // enable color
+	CARAPACE_COMPLINE             = "CARAPACE_COMPLINE"             // TODO
+	CARAPACE_COVERDIR             = "CARAPACE_COVERDIR"             // coverage directory for sandbox tests
+	CARAPACE_DESCRIPTION_LENGTH   = "CARAPACE_DESCRIPTION_LENGTH"   // maximum description length
+	CARAPACE_EXPERIMENTAL         = "CARAPACE_EXPERIMENTAL"         // enable experimental features
+	CARAPACE_HIDDEN               = "CARAPACE_HIDDEN"               // show hidden commands/flags
+	CARAPACE_LENIENT              = "CARAPACE_LENIENT"              // allow unknown flags
+	CARAPACE_LOG                  = "CARAPACE_LOG"                  // enable logging
+	CARAPACE_MATCH                = "CARAPACE_MATCH"                // match case insensitive
+	CARAPACE_MERGEFLAGS           = "CARAPACE_MERGEFLAGS"           // merge flags to single tag group
+	CARAPACE_NOSPACE              = "CARAPACE_NOSPACE"              // nospace suffixes
+	CARAPACE_SANDBOX              = "CARAPACE_SANDBOX"              // mock context for sandbox tests
+	CARAPACE_TOOLTIP              = "CARAPACE_TOOLTIP"              // enable tooltip style
+	CARAPACE_UNFILTERED           = "CARAPACE_UNFILTERED"           // skip the final filtering step
+	CARAPACE_ZSH_HASH_DIRS        = "CARAPACE_ZSH_HASH_DIRS"        // zsh hash directories
+	CARAPACE_ZSH_NO_COMMON_PREFIX = "CARAPACE_ZSH_NO_COMMON_PREFIX" // prevent zsh common prefix insertion
+	CLICOLOR                      = "CLICOLOR"                      // disable color
+	NO_COLOR                      = "NO_COLOR"                      // disable color
 )
 
 func ColorDisabled() bool {
@@ -117,6 +118,10 @@ func Compline() string {
 
 func Unfiltered() bool {
 	return getBool(CARAPACE_UNFILTERED)
+}
+
+func ZshNoCommonPrefix() bool {
+	return getBool(CARAPACE_ZSH_NO_COMMON_PREFIX)
 }
 
 func getBool(s string) bool {

--- a/internal/shell/zsh/snippet.go
+++ b/internal/shell/zsh/snippet.go
@@ -4,6 +4,7 @@ package zsh
 import (
 	"fmt"
 
+	"github.com/carapace-sh/carapace/internal/env"
 	"github.com/carapace-sh/carapace/pkg/uid"
 	"github.com/spf13/cobra"
 )
@@ -31,6 +32,8 @@ function _%[1]v_completion {
   zstyle ":completion:${curcontext}:*" list-colors "${zstyle}"
   zstyle ":completion:${curcontext}:*" group-name ''
   [ -z "$message" ] || _message -r "${message}"
+  local describeOptions
+  [ "${%[3]v}" = true ] || [ "${%[3]v}" = 1 ] && describeOptions=(-U)
   
   local block tag displays values displaysArr valuesArr
   while IFS=$'\002' read -r -d $'\002' block; do
@@ -39,10 +42,9 @@ function _%[1]v_completion {
     IFS=$'\n' read -r -d $'\004' -A displaysArr <<<"${displays}"$'\004'
     IFS=$'\n' read -r -d $'\004' -A valuesArr <<<"${values}"$'\004'
   
-    [[ ${#valuesArr[@]} -gt 1 ]] && _describe -t "${tag}" "${tag}" displaysArr valuesArr -Q -S ''
+    [[ ${#valuesArr[@]} -gt 1 ]] && _describe -t "${tag}" "${tag}" displaysArr valuesArr -Q -S '' "${describeOptions[@]}"
   done <<<"${data}"
 }
 compquote '' 2>/dev/null && _%[1]v_completion
-compdef _%[1]v_completion %[1]v
-`, cmd.Name(), uid.Executable())
+compdef _%[1]v_completion %[1]v`, cmd.Name(), uid.Executable(), env.CARAPACE_ZSH_NO_COMMON_PREFIX)
 }


### PR DESCRIPTION
Closes #1213.

## Summary
- add `CARAPACE_ZSH_NO_COMMON_PREFIX` as an opt-in zsh completion setting
- pass `-U` to `_describe` when enabled, so zsh does not insert a common prefix before showing matches
- update the generated zsh snippet fixture and snippet coverage so the option remains wired

## Verification
- `go test ./example/cmd -run TestZsh -count=1`
- `go test . -run TestSnippet -count=1`
- `go test ./internal/env ./internal/shell/zsh . -run TestSnippet -count=1`
- `go run ./example _carapace zsh | zsh -n`

Note: local `go test ./...` reports existing golden/sandbox failures in this checkout; the root-package subset also reproduces on `master` before this branch.