### PR TITLE
zsh: fix special character escaping in values

### DIFF
--- a/internal/shell/zsh/action.go
+++ b/internal/shell/zsh/action.go
@@ -57,6 +57,10 @@ var describeReplacer = strings.NewReplacer(
 	`:`, `\:`,
 )
 
+var describeValueReplacer = strings.NewReplacer(
+	`:`, `\:`,
+)
+
 func quoteValue(s string) string {
 	if strings.HasPrefix(s, "~/") || NamedDirectories.Matches(s) {
 		return "~" + defaultReplacer.Replace(strings.TrimPrefix(s, "~")) // assume file path expansion
@@ -119,21 +123,21 @@ func ActionRawValues(currentWord string, meta common.Meta, values common.RawValu
 			switch state {
 			case QUOTING_ESCAPING_STATE:
 				value = quotingEscapingReplacer.Replace(value)
-				value = describeReplacer.Replace(value)
+				value = describeValueReplacer.Replace(value)
 				value = value + `"`
 			case QUOTING_STATE:
 				value = quotingReplacer.Replace(value)
-				value = describeReplacer.Replace(value)
+				value = describeValueReplacer.Replace(value)
 				value = value + `'`
 			case FULL_QUOTING_ESCAPING_STATE:
 				value = quotingEscapingReplacer.Replace(value)
-				value = describeReplacer.Replace(value)
+				value = describeValueReplacer.Replace(value)
 			case FULL_QUOTING_STATE:
 				value = quotingReplacer.Replace(value)
-				value = describeReplacer.Replace(value)
+				value = describeValueReplacer.Replace(value)
 			default:
 				value = quoteValue(value)
-				value = describeReplacer.Replace(value)
+				value = describeValueReplacer.Replace(value)
 			}
 
 			if !meta.Nospace.Matches(val.Value) {

--- a/internal/shell/zsh/action_test.go
+++ b/internal/shell/zsh/action_test.go
@@ -1,0 +1,43 @@
+package zsh
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/carapace-sh/carapace/internal/common"
+)
+
+func TestActionRawValuesEscapesSpecialCharactersOnce(t *testing.T) {
+	output := ActionRawValues("", common.Meta{}, common.RawValuesFrom("Test2&Testaaa.txt", "spaceT TT.x", "foo:bar"))
+
+	want := []string{
+		`Test2\&Testaaa.txt `,
+		`spaceT\ TT.x `,
+		`foo\:bar `,
+	}
+	if got := valuesFromOutput(t, output); !slices.Equal(got, want) {
+		t.Fatalf("values mismatch:\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func valuesFromOutput(t *testing.T, output string) []string {
+	t.Helper()
+
+	fields := strings.Split(output, "\001")
+	if len(fields) != 4 {
+		t.Fatalf("expected four output fields, got %d in %#v", len(fields), output)
+	}
+
+	groups := strings.Split(strings.TrimSuffix(fields[2], "\002"), "\002")
+	if len(groups) != 1 {
+		t.Fatalf("expected one tag group, got %d in %#v", len(groups), fields[2])
+	}
+
+	block := strings.Split(groups[0], "\003")
+	if len(block) != 3 {
+		t.Fatalf("expected three tag group fields, got %d in %#v", len(block), groups[0])
+	}
+
+	return strings.Split(block[2], "\n")
+}


### PR DESCRIPTION
Fixes #1207.

## Summary
- keep zsh `_describe` display escaping unchanged
- only escape colons for completion values after shell quoting, avoiding a second backslash before special characters
- add a regression test for `&`, spaces, and `:` in zsh values

## Tests
- `go test ./internal/shell/zsh`
- `go test ./internal/shell/...`
- `env CARAPACE_COLOR=1 go test ./...`