### PR TITLE
nushell: upsert external completer in init snippet

### DIFF
--- a/example/cmd/_test/nushell.nu
+++ b/example/cmd/_test/nushell.nu
@@ -1,3 +1,15 @@
-let example_completer = {|spans| 
+let example_completer = {|spans|
     example _carapace nushell ...$spans | from json
 }
+
+let example_previous_completer = ($env.config.completions.external.completer? | default {|spans| null })
+$env.config = ($env.config | upsert completions.external {
+    enable: true
+    completer: {|spans|
+        if $spans.0 == "example" {
+            do $example_completer $spans
+        } else {
+            do $example_previous_completer $spans
+        }
+    }
+})

--- a/internal/shell/nushell/snippet.go
+++ b/internal/shell/nushell/snippet.go
@@ -10,7 +10,19 @@ import (
 
 // Snippet creates the nushell completion script.
 func Snippet(cmd *cobra.Command) string {
-	return fmt.Sprintf(`let %v_completer = {|spans| 
-    %v _carapace nushell ...$spans | from json
-}`, cmd.Name(), uid.Executable())
+	return fmt.Sprintf(`let %[1]v_completer = {|spans|
+    %[2]v _carapace nushell ...$spans | from json
+}
+
+let %[1]v_previous_completer = ($env.config.completions.external.completer? | default {|spans| null })
+$env.config = ($env.config | upsert completions.external {
+    enable: true
+    completer: {|spans|
+        if $spans.0 == %[1]q {
+            do $%[1]v_completer $spans
+        } else {
+            do $%[1]v_previous_completer $spans
+        }
+    }
+})`, cmd.Name(), uid.Executable())
 }


### PR DESCRIPTION
## Summary

When `<cmd> _carapace nushell` is sourced, it now registers the new completer into `$env.config.completions.external` rather than only defining the closure. Multiple completers can coexist by chaining: the snippet captures the previous completer at registration time and falls back to it for commands other than the registered one. This addresses the user's request in #1217 while preserving any pre-existing external completer.

Generated snippet for `example`:

```nu
let example_completer = {|spans|
    example _carapace nushell ...$spans | from json
}

let example_previous_completer = ($env.config.completions.external.completer? | default {|spans| null })
$env.config = ($env.config | upsert completions.external {
    enable: true
    completer: {|spans|
        if $spans.0 == "example" {
            do $example_completer $spans
        } else {
            do $example_previous_completer $spans
        }
    }
})
```

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (all tests pass, including `TestNushell` against the updated fixture in `example/cmd/_test/nushell.nu`)
- [x] `gofmt -w .` (no changes)

Fixes #1217.

/claim #1217