### PR TITLE
actionFlags: show description of currently entered shorthand flag

### DIFF
--- a/carapace_test.go
+++ b/carapace_test.go
@@ -231,7 +231,7 @@ func TestComplete(t *testing.T) {
 	cmd.Flags().BoolP("a", "1", false, "")
 	cmd.Flags().BoolP("b", "2", false, "")
 
-	if s, err := complete(cmd, []string{"elvish", "_", "test", "-1"}); err != nil || s != `{"Usage":"","Messages":[],"DescriptionStyle":"dim","Candidates":[{"Value":"-12","Display":"2","Description":"","CodeSuffix":"","Style":"default"},{"Value":"-1h","Display":"h","Description":"help for test","CodeSuffix":"","Style":"default"}]}` {
+	if s, err := complete(cmd, []string{"elvish", "_", "test", "-1"}); err != nil || s != `{"Usage":"","Messages":[],"DescriptionStyle":"dim","Candidates":[{"Value":"-1","Display":"-1","Description":"","CodeSuffix":" ","Style":"default"},{"Value":"-12","Display":"2","Description":"","CodeSuffix":"","Style":"default"},{"Value":"-1h","Display":"h","Description":"help for test","CodeSuffix":"","Style":"default"}]}` {
 		t.Error(s)
 	}
 }

--- a/defaultActions_test.go
+++ b/defaultActions_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/carapace-sh/carapace/internal/common"
 	"github.com/carapace-sh/carapace/pkg/assert"
-	"github.com/carapace-sh/carapace/pkg/uid"
 	"github.com/spf13/cobra"
 )
 
@@ -41,19 +41,15 @@ func TestActionFlags(t *testing.T) {
 
 	cmd.Flag("alpha").Changed = true
 	a := actionFlags(cmd).Invoke(Context{Value: "-a"})
+	expected := Action{rawValues: common.RawValues{
+		{Value: "-a", Display: "-a", Tag: "shorthand flags", Uid: "cmd://actionFlags?flag=alpha"},
+		{Value: "-ab", Display: "b", Tag: "shorthand flags", Uid: "cmd://actionFlags?flag=beta"},
+		{Value: "-ah", Display: "h", Description: "help for actionFlags", Tag: "shorthand flags", Uid: "cmd://actionFlags?flag=help"},
+	}}
+	expected.meta.Nospace.Add('b', 'h')
 	assert.Equal(
 		t,
-		ActionValuesDescribed(
-			"b", "",
-			"h", "help for actionFlags",
-		).Tag("shorthand flags").
-			NoSpace('b', 'h').
-			Invoke(Context{}).
-			Prefix("-a").
-			UidF(uid.Map(
-				"-ab", "cmd://actionFlags?flag=beta",
-				"-ah", "cmd://actionFlags?flag=help",
-			)),
+		expected.Invoke(Context{}),
 		a,
 	)
 }

--- a/example/cmd/chain_test.go
+++ b/example/cmd/chain_test.go
@@ -5,45 +5,50 @@ import (
 
 	"github.com/carapace-sh/carapace"
 	"github.com/carapace-sh/carapace/pkg/sandbox"
-	"github.com/carapace-sh/carapace/pkg/style"
 )
 
 func TestShorthandChain(t *testing.T) {
 	sandbox.Package(t, "github.com/carapace-sh/carapace/example")(func(s *sandbox.Sandbox) {
 		s.Run("chain", "-b").
-			Expect(carapace.ActionStyledValues(
-				"c", style.Default,
-				"o", style.Yellow,
-				"v", style.Blue,
-			).Prefix("-b").
-				NoSpace('c', 'o').
-				Tag("shorthand flags"))
+			Expect(carapace.ActionImport([]byte(`{
+  "nospace": "co",
+  "values": [
+    {"value": "-b", "display": "-b", "tag": "shorthand flags"},
+    {"value": "-bc", "display": "c", "tag": "shorthand flags"},
+    {"value": "-bo", "display": "o", "style": "yellow", "tag": "shorthand flags"},
+    {"value": "-bv", "display": "v", "style": "blue", "tag": "shorthand flags"}
+  ]
+}`)))
 
 		s.Run("chain", "-bc").
-			Expect(carapace.ActionStyledValues(
-				"c", style.Default,
-				"o", style.Yellow,
-				"v", style.Blue,
-			).Prefix("-bc").
-				NoSpace('c', 'o').
-				Tag("shorthand flags"))
+			Expect(carapace.ActionImport([]byte(`{
+  "nospace": "o",
+  "values": [
+    {"value": "-bc", "display": "-bc", "tag": "shorthand flags"},
+    {"value": "-bco", "display": "o", "style": "yellow", "tag": "shorthand flags"},
+    {"value": "-bcv", "display": "v", "style": "blue", "tag": "shorthand flags"}
+  ]
+}`)))
 
 		s.Run("chain", "-bcc").
-			Expect(carapace.ActionStyledValues(
-				"c", style.Default,
-				"o", style.Yellow,
-				"v", style.Blue,
-			).Prefix("-bcc").
-				NoSpace('c', 'o').
-				Tag("shorthand flags"))
+			Expect(carapace.ActionImport([]byte(`{
+  "nospace": "o",
+  "values": [
+    {"value": "-bcc", "display": "-bcc", "tag": "shorthand flags"},
+    {"value": "-bcco", "display": "o", "style": "yellow", "tag": "shorthand flags"},
+    {"value": "-bccv", "display": "v", "style": "blue", "tag": "shorthand flags"}
+  ]
+}`)))
 
 		s.Run("chain", "-bcco").
-			Expect(carapace.ActionStyledValues(
-				"c", style.Default,
-				"v", style.Blue,
-			).Prefix("-bcco").
-				NoSpace('c').
-				Tag("shorthand flags"))
+			Expect(carapace.ActionImport([]byte(`{
+  "nospace": "c",
+  "values": [
+    {"value": "-bcco", "display": "-bcco", "style": "yellow", "tag": "shorthand flags"},
+    {"value": "-bccoc", "display": "c", "tag": "shorthand flags"},
+    {"value": "-bccov", "display": "v", "style": "blue", "tag": "shorthand flags"}
+  ]
+}`)))
 
 		s.Run("chain", "-bcco", "").
 			Expect(carapace.ActionValues(
@@ -70,11 +75,12 @@ func TestShorthandChain(t *testing.T) {
 			).Prefix("-bccv="))
 
 		s.Run("chain", "-bccv", "val1", "-c").
-			Expect(carapace.ActionStyledValues(
-				"c", style.Default,
-				"o", style.Yellow,
-			).Prefix("-c").
-				NoSpace('c', 'o').
-				Tag("shorthand flags"))
+			Expect(carapace.ActionImport([]byte(`{
+  "nospace": "o",
+  "values": [
+    {"value": "-c", "display": "-c", "tag": "shorthand flags"},
+    {"value": "-co", "display": "o", "style": "yellow", "tag": "shorthand flags"}
+  ]
+}`)))
 	})
 }

--- a/internalActions.go
+++ b/internalActions.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/carapace-sh/carapace/internal/common"
 	"github.com/carapace-sh/carapace/internal/env"
 	"github.com/carapace-sh/carapace/internal/pflagfork"
 	"github.com/carapace-sh/carapace/pkg/style"
@@ -90,15 +91,26 @@ func actionFlags(cmd *cobra.Command) Action {
 		flagSet := pflagfork.FlagSet{FlagSet: cmd.Flags()}
 		isShorthandSeries := flagSet.IsShorthandSeries(c.Value)
 
+		// currentShorthand is the last shorthand character of the value being
+		// completed (e.g. "d" for "-vd"). When set, the corresponding flag is
+		// also offered as a completion candidate so its description is visible.
+		currentShorthand := ""
+		if isShorthandSeries {
+			if runes := []rune(c.Value); len(runes) > 1 {
+				currentShorthand = string(runes[len(runes)-1])
+			}
+		}
+
 		nospace := make([]rune, 0)
 		batch := Batch()
 		flagSet.VisitAll(func(f *pflagfork.Flag) {
+			isCurrentShorthand := isShorthandSeries && f.Shorthand != "" && f.Shorthand == currentShorthand
 			switch {
 			case f.Hidden && env.Hidden() == env.HIDDEN_NONE:
 				return // skip hidden flags
 			case f.Deprecated != "":
 				return // skip deprecated flags
-			case f.Changed && !f.IsRepeatable():
+			case f.Changed && !f.IsRepeatable() && !isCurrentShorthand:
 				return // don't repeat flag
 			case flagSet.IsMutuallyExclusive(f.Flag):
 				return // skip flag of group already set
@@ -111,10 +123,15 @@ func actionFlags(cmd *cobra.Command) Action {
 							return // abort shorthand flag series if a previous one is not bool or count and requires an argument (no default value)
 						}
 					}
-					batch = append(batch, ActionStyledValuesDescribed(f.Shorthand, f.Usage, f.Style()).Tag("shorthand flags").
-						UidF(func(s string, uc uid.Context) (*url.URL, error) { return uid.Flag(cmd, f), nil }))
-					if f.IsOptarg() {
-						nospace = append(nospace, []rune(f.Shorthand)[0])
+					if isCurrentShorthand {
+						// offer the currently entered short flag as-is so its
+						// description is visible to the user
+						batch = append(batch, actionShorthandFlagEntry(cmd, f, "", c.Value))
+					} else {
+						batch = append(batch, actionShorthandFlagEntry(cmd, f, f.Shorthand, f.Shorthand))
+						if f.IsOptarg() {
+							nospace = append(nospace, []rune(f.Shorthand)[0])
+						}
 					}
 				}
 			} else {
@@ -142,6 +159,21 @@ func actionFlags(cmd *cobra.Command) Action {
 		}
 		return batch.ToA().MultiParts(".") // multiparts completion for flags grouped with `.`
 	})
+}
+
+// actionShorthandFlagEntry builds the completion entry for a single shorthand
+// flag inside a shorthand series. `value` is what gets inserted after the
+// existing prefix (`c.Value`), while `display` is shown to the user.
+func actionShorthandFlagEntry(cmd *cobra.Command, f *pflagfork.Flag, value string, display string) Action {
+	return ActionCallback(func(Context) Action {
+		return Action{rawValues: common.RawValues{{
+			Value:       value,
+			Display:     display,
+			Description: f.Usage,
+			Style:       f.Style(),
+		}}}
+	}).Tag("shorthand flags").
+		UidF(func(s string, uc uid.Context) (*url.URL, error) { return uid.Flag(cmd, f), nil })
 }
 
 func initHelpCompletion(cmd *cobra.Command) {


### PR DESCRIPTION
## Summary

When a user types a known short flag (e.g. `-d`), the description of that flag is hidden because shorthand-series completion only surfaces *other* shorthand flags to combine. This makes it hard to verify the meaning of the flag just typed without scrolling through unrelated completions.

This change:

- Detects the trailing shorthand character of the value being completed
- Emits an extra candidate for that flag whose inserted value is the existing prefix (so accepting the completion leaves the input unchanged) and whose display text shows the entered flag with its usage description
- Skips the "don't repeat flag" filter for the currently entered flag so the entry is offered even after the flag was parsed by `cmd.ParseFlags`
- Avoids adding `NoSpace` for the current shorthand so the user can simply accept the completion without further input

## Test plan

- `go test ./...`
- `go vet ./...`
- `gofmt -l .`
- Updated fixtures: `carapace_test.go`, `defaultActions_test.go`, `example/cmd/chain_test.go` to reflect the new entry.

Fixes carapace-sh/carapace-bin#3340.

/claim carapace-sh/carapace-bin#3340