### PR TITLE
uid: fix race condition in Flag() by holding mutex during recursion

### DIFF
--- a/pkg/uid/uid.go
+++ b/pkg/uid/uid.go
@@ -70,11 +70,15 @@ var mLocalFlags sync.Mutex
 // Flag creates a uid for given flag.
 func Flag(cmd *cobra.Command, flag *pflagfork.Flag) *url.URL {
 	mLocalFlags.Lock()
-	fs := cmd.LocalFlags() // TODO causes a concurrent map write without lock
-	mLocalFlags.Unlock()
+	defer mLocalFlags.Unlock()
+	return flagRecursive(cmd, flag)
+}
 
-	if fs.Lookup(flag.Name) == nil && cmd.HasParent() {
-		return Flag(cmd.Parent(), flag)
+func flagRecursive(cmd *cobra.Command, flag *pflagfork.Flag) *url.URL {
+	_ = cmd.LocalFlags() // Force flag merge; not thread-safe internally
+
+	if cmd.LocalFlags().Lookup(flag.Name) == nil && cmd.HasParent() {
+		return flagRecursive(cmd.Parent(), flag)
 	}
 	uid := Command(cmd)
 	values := uid.Query()


### PR DESCRIPTION
The mutex was previously only held during the initial LocalFlags() call,
but the recursive traversal to parent commands happened outside the lock.
This could cause concurrent map write issues when multiple goroutines
called Flag() simultaneously.

Now uses a helper function flagRecursive() that stays within the mutex
for the entire operation.

Assisted-by: Crush:minimax-m2.7
