### PR TITLE
fix: correctly handle flag names that overlap with their shorthand in…

### DIFF
--- a/example-nonposix/cmd/root.go
+++ b/example-nonposix/cmd/root.go
@@ -31,6 +31,7 @@ func init() {
 	rootCmd.Flags().CountN("count", "c", "CountN")
 	rootCmd.Flags().StringSlice("nargs-any", []string{}, "Nargs")
 	rootCmd.Flags().StringSlice("nargs-two", []string{}, "Nargs")
+	rootCmd.Flags().StringN("overlapping", "o", "", "overlapping shorthand")
 
 	rootCmd.Flag("delim-colon").NoOptDefVal = " "
 	rootCmd.Flag("delim-colon").OptargDelimiter = ':'
@@ -57,6 +58,7 @@ func init() {
 				return carapace.ActionValues()
 			}
 		}),
+		"overlapping": carapace.ActionValues("o1", "o2", "o3"),
 	})
 
 	carapace.Gen(rootCmd).PositionalCompletion(

--- a/example-nonposix/cmd/root_test.go
+++ b/example-nonposix/cmd/root_test.go
@@ -110,3 +110,42 @@ func TestNargs(t *testing.T) {
 				Tag("longhand flags"))
 	})
 }
+
+func TestOverlapping(t *testing.T) {
+	sandbox.Package(t, "github.com/carapace-sh/carapace/example-nonposix")(func(s *sandbox.Sandbox) {
+		s.Run("-o").
+			Expect(
+				carapace.Batch(
+					carapace.ActionValuesDescribed(
+						"-o", "overlapping shorthand",
+					).Tag("shorthand flags"),
+					carapace.ActionValuesDescribed(
+						"-overlapping", "overlapping shorthand",
+					).Tag("longhand flags"),
+				).ToA().
+					Style(style.Blue).
+					NoSpace('.'))
+
+		s.Run("-ov").
+			Expect(
+				carapace.ActionValuesDescribed(
+					"-overlapping", "overlapping shorthand",
+				).Tag("longhand flags").
+					Style(style.Blue).
+					NoSpace('.'))
+
+		s.Run("-o", "").
+			Expect(carapace.ActionValues(
+				"o1",
+				"o2",
+				"o3",
+			).Usage("overlapping shorthand"))
+
+		s.Run("-overlapping", "").
+			Expect(carapace.ActionValues(
+				"o1",
+				"o2",
+				"o3",
+			).Usage("overlapping shorthand"))
+	})
+}

--- a/example-nonposix/go.mod
+++ b/example-nonposix/go.mod
@@ -5,7 +5,7 @@ go 1.24
 require (
 	github.com/carapace-sh/carapace v0.50.3-0.20240311124258-a5adf91d8b8f
 	github.com/spf13/cobra v1.10.2
-	github.com/spf13/pflag v1.0.9
+	github.com/spf13/pflag v1.0.10
 )
 
 require (
@@ -16,4 +16,4 @@ require (
 
 replace github.com/carapace-sh/carapace => ../
 
-replace github.com/spf13/pflag => github.com/carapace-sh/carapace-pflag v1.1.0
+replace github.com/spf13/pflag => github.com/carapace-sh/carapace-pflag v1.1.1

--- a/example-nonposix/go.sum
+++ b/example-nonposix/go.sum
@@ -1,5 +1,5 @@
-github.com/carapace-sh/carapace-pflag v1.1.0 h1:uB33wch8ADjP878NadQnbZ5vyROcj/Ac+wUQKMcIrQM=
-github.com/carapace-sh/carapace-pflag v1.1.0/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/carapace-sh/carapace-pflag v1.1.1 h1:gjK1pmIqWgubelqzavrlYRpmD+OLwbFEIJ8kJaCnAwY=
+github.com/carapace-sh/carapace-pflag v1.1.1/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/carapace-sh/carapace-shlex v1.1.1 h1:ccmNeetAYZOk4IcV36youFDsXusT9uCNW2Njkw+QS+Q=
 github.com/carapace-sh/carapace-shlex v1.1.1/go.mod h1:lJ4ZsdxytE0wHJ8Ta9S7Qq0XpjgjU0mdfCqiI2FHx7M=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
@@ -7,6 +7,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
+github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/pflagfork/flagset.go
+++ b/internal/pflagfork/flagset.go
@@ -62,6 +62,11 @@ func (fs FlagSet) LookupArg(arg string) (result *Flag) {
 	case isPosix:
 		return fs.lookupPosixShorthandArg(arg)
 	case !isPosix:
+		// In non-posix mode, try longhand first (single dash with name)
+		// to handle cases where name overlaps with shorthand
+		if result = fs.LookupNonPosixLonghandArg(arg); result != nil {
+			return result
+		}
 		return fs.lookupNonPosixShorthandArg(arg)
 	}
 	return
@@ -151,4 +156,17 @@ func (fs FlagSet) lookupNonPosixShorthandArg(arg string) (result *Flag) { // TOD
 		}
 	})
 	return
+}
+
+// LookupNonPosixLonghandArg looks up a non-posix longhand argument (single dash with name)
+func (fs FlagSet) LookupNonPosixLonghandArg(arg string) *Flag {
+	if !strings.HasPrefix(arg, "-") || strings.HasPrefix(arg, "--") {
+		return nil
+	}
+
+	name := arg[1:] // remove single dash
+	if flag := fs.Lookup(name); flag != nil {
+		return &Flag{Flag: flag, Args: []string{}}
+	}
+	return nil
 }


### PR DESCRIPTION
… non-posix mode

In non-posix mode, flags like `-overlapping` with shorthand `o` were being misinterpreted as shorthand `-o` missing its argument. This adds proper lookup prioritizing longhand names over shorthand letters.

The fix ensures that when a flag name (like "overlapping") starts with a shorthand character (like "o"), the parser correctly identifies it as a longhand flag when used with a single dash, rather than treating the remaining characters as an argument to the shorthand.

Assisted-by: Crush:minimax-m2.7

fix #1226 