### PR TITLE
carapace-dev: add 11 internal reference docs

### DIFF
--- a/skills/carapace-dev/SKILL.md
+++ b/skills/carapace-dev/SKILL.md
@@ -33,6 +33,17 @@ Load the reference that matches your task. When in doubt, load multiple referenc
 | Xonsh, RichCompletion, prefix_len, append_closing_quote, contextual_command_completer | [references/shell-xonsh.md](references/shell-xonsh.md) |
 | Style system, XTerm256, TrueColor, ForKeyword, ForPath, ForPathExt, LS_COLORS, style config | [references/style.md](references/style.md) |
 | Bridge, bridgeActions, actionCommand, output parsing, NoSpace detection, shell config, Detect() | [references/bridge.md](references/bridge.md) |
+| Storage, global map, mutex, entry, FlagCompletion, PositionalCompletion, PreRun, PreInvoke, storage.get, gotchas | [references/storage.md](references/storage.md) |
+| Sandbox, Command, Package, Action, Files, Reply, Run, Expect, ExpectNot, ClearCache, SANDBOX env, subprocess isolation | [references/sandbox.md](references/sandbox.md) |
+| Batch, Invoke, parallelize, Merge, ToA, invokedBatch, goroutine model, shared Context, parallel invocation | [references/batch.md](references/batch.md) |
+| Cache, Action.Cache, File, Load, Write, cache key, file:line, key.Key types, FolderStats, TTL, sandbox override | [references/cache.md](references/cache.md) |
+| UID, url.URL, cmd:// scheme, Command, Flag, mLocalFlags mutex, PathEscape, Executable, UidF, uid.Map | [references/uid.md](references/uid.md) |
+| Config, styles.json, RegisterStyle, Load, CARAPACE_* env vars, LOG, ColorDisabled, Hidden, Sandbox, isGoRun | [references/config-env.md](references/config-env.md) |
+| Spec, spec.Spec, yaml.Marshal, Command struct, Flags, PersistentFlags, _carapace skip, pflagfork.Flag.Definition | [references/spec.md](references/spec.md) |
+| Export, Export struct, MarshalJSON, version, RawValue, Meta, cache format, sandbox invoke, ActionImport | [references/export.md](references/export.md) |
+| Conditionals, Arch, Os, Executable, File, CompletingPath, UnlessF, Context predicates, pkg/condition | [references/conditionals.md](references/conditionals.md) |
+| _carapace CLI, command.go, addCompletionCommand, spec, style set, export re-invocation, PositionalAnyCompletion | [references/command-cli.md](references/command-cli.md) |
+| Mock, Mock struct, NewMock, Dir, Replies, CacheDir, WorkDir, t interface, Reply mechanism, sandbox integration | [references/mock.md](references/mock.md) |
 
 ## Quick Guide
 
@@ -43,6 +54,17 @@ Load the reference that matches your task. When in doubt, load multiple referenc
 - **How does a specific shell format completions?** → [references/shell-{name}.md](references/shell-bash.md)
 - **How do styles/colors work?** → [references/style.md](references/style.md)
 - **How do bridges work internally?** → [references/bridge.md](references/bridge.md)
+- **How does the global storage map work?** → [references/storage.md](references/storage.md)
+- **How do I write/run sandbox tests?** → [references/sandbox.md](references/sandbox.md)
+- **How does Batch parallel invocation work?** → [references/batch.md](references/batch.md)
+- **How does Action.Cache work?** → [references/cache.md](references/cache.md)
+- **How do UID identifiers work?** → [references/uid.md](references/uid.md)
+- **How is styles.json loaded?** → [references/config-env.md](references/config-env.md)
+- **How does spec YAML generation work?** → [references/spec.md](references/spec.md)
+- **What is the JSON wire format?** → [references/export.md](references/export.md)
+- **What conditional helpers exist?** → [references/conditionals.md](references/conditionals.md)
+- **How does the _carapace CLI work?** → [references/command-cli.md](references/command-cli.md)
+- **How does the mock system work?** → [references/mock.md](references/mock.md)
 
 ## Cross-Project References
 

--- a/skills/carapace-dev/references/batch.md
+++ b/skills/carapace-dev/references/batch.md
@@ -1,0 +1,143 @@
+# Carapace Library: Batch — Parallel Invocation
+
+Reference for [carapace](https://github.com/carapace-sh/carapace)'s `Batch` API and parallel action invocation model.
+
+## Batch Type
+
+```go
+type batch []Action
+type invokedBatch []InvokedAction
+```
+
+`Batch` wraps a slice of `Action` values for parallel invocation.
+
+## Invocation Model
+
+```go
+func (b batch) Invoke(c Context) invokedBatch {
+    invokedActions := make([]InvokedAction, len(b))
+    functions := make([]func(), len(b))
+
+    for index, action := range b {
+        localIndex := index
+        localAction := action
+        functions[index] = func() {
+            invokedActions[localIndex] = localAction.Invoke(c)
+        }
+    }
+    parallelize(functions...)
+    return invokedActions
+}
+```
+
+Each action is captured by index into a separate goroutine closure. `parallelize()` launches all goroutines and waits for completion before returning.
+
+## Parallelize
+
+```go
+func parallelize(functions ...func()) {
+    var waitGroup sync.WaitGroup
+    waitGroup.Add(len(functions))
+
+    defer waitGroup.Wait()
+
+    for _, function := range functions {
+        go func(copy func()) {
+            defer waitGroup.Done()
+            copy()
+        }(function)
+    }
+}
+```
+
+Uses `sync.WaitGroup` to coordinate goroutines. Each goroutine captures its function via closure copy (not a reference loop variable).
+
+## Merge
+
+```go
+func (b invokedBatch) Merge() InvokedAction {
+    switch len(b) {
+    case 0:
+        return ActionValues().Invoke(Context{})
+    case 1:
+        return b[0]
+    default:
+        return b[0].Merge(b[1:]...)
+    }
+}
+```
+
+Deduplicates by `(Value, Uid)` key, concatenates raw values, merges metadata. Single-item batch returns as-is (no extra allocation).
+
+## ToA — Lazy Batch
+
+```go
+func (b batch) ToA() Action {
+    return ActionCallback(func(c Context) Action {
+        return b.Invoke(c).Merge().ToA()
+    })
+}
+```
+
+Wraps the batch as a lazy action. The goroutines only launch when `Invoke()` is called.
+
+## Usage Pattern
+
+```go
+carapace.Batch(
+    carapace.ActionDirectories(),
+    carapace.ActionExecutables(),
+).ToA()
+```
+
+Equivalent to:
+```go
+carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+    return carapace.Batch(
+        carapace.ActionDirectories(),
+        carapace.ActionExecutables(),
+    ).Invoke(c).Merge().ToA()
+})
+```
+
+## InvokedAction Merge
+
+`InvokedAction.Merge()` combines multiple invoked actions:
+
+```go
+func (ia InvokedAction) Merge(others ...InvokedAction) InvokedAction {
+    merged := InvokedAction{
+        action: ia.action,
+    }
+    for _, o := range others {
+        merged.action.rawValues = append(merged.action.rawValues, o.action.rawValues...)
+        merged.action.meta.Merge(o.action.meta)
+    }
+    merged.action.rawValues.Unique() // dedup by (Value, Uid)
+    return merged
+}
+```
+
+Called by `invokedBatch.Merge()` to combine parallel results.
+
+## Combined with Traverse
+
+`traverse()` uses `Batch` when a positional argument has subcommands but no positionals consumed:
+
+```go
+Batch(getPositional(cmd, 0)) + ActionCommands(cmd)
+```
+
+This is the standard case for CLI tools where the first positional is a subcommand name.
+
+## Gotchas
+
+- **No early cutoff**: All goroutines launch regardless of whether earlier ones already produced enough results. For very slow actions, consider `Action.Timeout()` as a guard.
+- **Context is shared**: All parallel invocations receive the same `Context`. Mutations to `c.Dir` or `c.Env` by one goroutine are visible to others. Use `Action.Chdir()` on individual actions, not on the batch.
+- **Ordering preserved**: `invokedActions[i]` corresponds to `batch[i]`, so merge order is deterministic.
+- **PreInvoke in batch**: Actions in a batch have already gone through PreInvoke before being captured. Parallelism applies to the callback execution phase only.
+
+## Related Skills
+
+- **references/action.md** — InvokedAction type and its modifiers
+- **references/traverse.md** — where Batch is used in the completion decision

--- a/skills/carapace-dev/references/cache.md
+++ b/skills/carapace-dev/references/cache.md
@@ -1,0 +1,144 @@
+# Carapace Library: Cache System
+
+Reference for [carapace](https://github.com/carapace-sh/carapace)'s file-based cache for action callback results.
+
+## Action.Cache — Lazy Caching Modifier
+
+```go
+func (a Action) Cache(timeout time.Duration, keys ...key.Key) Action {
+    if a.callback != nil {
+        cachedCallback := a.callback
+        _, file, line, _ := runtime.Caller(1)
+        a.callback = func(c Context) Action {
+            cacheFile, err := cache.File(file, line, keys...)
+            if err != nil {
+                return cachedCallback(c)
+            }
+
+            if cached, err := cache.LoadE(cacheFile, timeout); err == nil {
+                return Action{meta: cached.Meta, rawValues: cached.Values}
+            }
+
+            invokedAction := (Action{callback: cachedCallback}).Invoke(c)
+            if invokedAction.action.meta.Messages.IsEmpty() {
+                if cacheFile, err := cache.File(file, line, keys...); err == nil {
+                    _ = cache.WriteE(cacheFile, invokedAction.export())
+                }
+            }
+            return invokedAction.ToA()
+        }
+    }
+    return a
+}
+```
+
+Only wraps actions with a `callback` (pre-computed `rawValues` skip caching). Uses `runtime.Caller(1)` to get the caller's file:line as the cache key base.
+
+## Cache Key Structure
+
+Cache files are stored at:
+
+```
+$XDG_CACHE_HOME/carapace/<executable>/<filehash>/<keyhash>
+```
+
+Where:
+- `<executable>` = `uid.Executable()` — name of the compiled binary
+- `<filehash>` = SHA1 of `file\001line` (the caller's `runtime.Caller(1)` location)
+- `<keyhash>` = SHA1 of all `key.Key` values joined by `\001`
+
+Example path:
+
+```
+~/.cache/carapace/git/3a2f1c9b/1d4e5f7a2b3c...
+```
+
+## Cache Key Types
+
+`pkg/cache/key/cache.go` provides `Key` func types:
+
+| Key | Purpose |
+|-----|---------|
+| `key.String(s ...string)` | Static strings as key components |
+| `key.FileChecksum(file)` | SHA1 of file content |
+| `key.FileStats(file)` | `path + size + mtime` for file changes |
+| `key.FolderStats(folder)` | Aggregate stats of all files in folder |
+
+```go
+// Cache until go.mod changes
+ActionExecCommand("go", "list", "-m")(...).Cache(10*time.Minute, key.FileChecksum("go.mod"))
+
+// Cache until any file in vendor/ changes
+ActionExecCommand("ls", "vendor/")(...).Cache(5*time.Minute, key.FolderStats("vendor"))
+```
+
+## TTL / Timeout
+
+```go
+cache.Load(file, timeout time.Duration)
+```
+
+`timeout < 0` means infinite (never expire). `timeout = 0` means always revalidate. `timeout > 0` expires entries older than the duration.
+
+## Cache File Format
+
+Cache stores a JSON-encoded `export.Export`:
+
+```go
+type Export struct {
+    Version string       `json:"version"`
+    Meta    common.Meta  `json:"meta"`
+    Values  common.RawValues `json:"values"`
+}
+```
+
+Same format as the `export` shell target. Written via `cache.WriteE()` which JSON-marshals and calls `os.WriteFile` with `0600` permissions.
+
+## Sandbox Override
+
+When `CARAPACE_SANDBOX` is set, `cache.CacheDir()` redirects to the sandbox's cache directory:
+
+```go
+func CacheDir(name string) (dir string, err error) {
+    userCacheDir, err = xdg.UserCacheDir()
+    if m, sandboxErr := env.Sandbox(); sandboxErr == nil {
+        userCacheDir = m.CacheDir() // sandbox temp dir
+    }
+    dir = fmt.Sprintf("%v/carapace/%v/%v", userCacheDir, uid.Executable(), name)
+    os.MkdirAll(dir, 0700)
+    return
+}
+```
+
+Sandbox cache dir: `<sandbox_tmpdir>/cache/carapace/<executable>/...`
+
+## Coverage Integration
+
+`CARAPACE_COVERDIR` is a custom env variable (distinct from `GOCOVERDIR`) that tells the sandbox where to write coverage data:
+
+```go
+func CoverDir() string {
+    return os.Getenv("CARAPACE_COVERDIR")
+}
+```
+
+Used by integration tests to collect coverage from sandbox subprocesses alongside unit test coverage.
+
+## Write Path
+
+`cache.WriteE()` uses JSON marshal, then `Write()` which calls `os.WriteFile`. No intermediate temp file — directly writes to the target path.
+
+## Gotchas
+
+- **Cache key = file:line**: Moving a `.Cache()` call changes the cache key and invalidates all cached entries for that action. Cache is per-call-site, not per-action-definition.
+- **Messages suppress cache write**: If `Messages` is not empty, the cache is not written. This prevents caching error states or informational messages.
+- **Cache keys regenerated after invoke**: The second call to `cache.File()` inside the callback regenerates the key in case the keys depend on `Context` values that changed between invocation start and now.
+- **0600 permissions**: Cache files are owner-read/write only to prevent exposure of potentially sensitive completion data.
+- **Sandbox isolation**: Each sandbox test gets its own cache directory via `mock.CacheDir()`. `s.ClearCache()` removes it between subtests.
+- **Timeout = 0**: Means always revalidate (stat the file and check mtime). The `Load` function returns error if the file is older than `timeout`.
+
+## Related Skills
+
+- **references/action.md** — the `Cache()` modifier on Action
+- **references/sandbox.md** — sandbox cache directory and ClearCache
+- **internal/export/** — the Export struct stored in cache files

--- a/skills/carapace-dev/references/command-cli.md
+++ b/skills/carapace-dev/references/command-cli.md
@@ -1,0 +1,186 @@
+# Carapace Library: _carapace CLI
+
+Reference for [carapace](https://github.com/carapace-sh/carapace)'s hidden `_carapace` subcommand and its subcommands in `command.go`.
+
+## Registration
+
+`carapace.Gen(cmd)` calls `addCompletionCommand(targetCmd)` which adds the `_carapace` subcommand to any command that doesn't already have one:
+
+```go
+func addCompletionCommand(targetCmd *cobra.Command) {
+    for _, c := range targetCmd.Commands() {
+        if c.Name() == "_carapace" {
+            return
+        }
+    }
+    // add _carapace subcommand
+}
+```
+
+The subcommand is `Hidden: true` and uses `DisableFlagParsing: true` with `UnknownFlags: true` to handle unknown flags gracefully during completion.
+
+## _carapace Entry Point
+
+```go
+carapaceCmd := &cobra.Command{
+    Use:    "_carapace",
+    Hidden: true,
+    Run: func(cmd *cobra.Command, args []string) {
+        LOG.Print(strings.Repeat("-", 80))
+        LOG.Printf("%#v", os.Args)
+
+        if len(args) > 2 && strings.HasPrefix(args[2], "_") {
+            cmd.Hidden = false
+        }
+
+        if !cmd.HasParent() {
+            panic("missing parent command")
+        }
+
+        parentCmd := cmd.Parent()
+        if parentCmd.Annotations[annotation_standalone] == "true" {
+            parentCmd.RemoveCommand(cmd) // don't complete local _carapace in standalone mode
+        }
+
+        if s, err := complete(parentCmd, args); err != nil {
+            fmt.Fprintln(io.MultiWriter(parentCmd.OutOrStderr(), LOG.Writer()), err.Error())
+        } else {
+            fmt.Fprintln(io.MultiWriter(parentCmd.OutOrStdout(), LOG.Writer()), s)
+        }
+    },
+}
+```
+
+Arguments to `_carapace`:
+- `args[0]` = shell name (e.g., `"bash"`, `"zsh"`)
+- `args[1]` = root command name (e.g., `"git"`)
+- `args[2+]` = completion arguments (e.g., `"branch"`, `"--force"`)
+
+## Dispatch to complete()
+
+`complete(parentCmd, args)` is the main dispatch function (in `complete.go`). It handles:
+- 0 args: output snippet for auto-detected shell
+- 1 arg: output snippet for named shell
+- 2+ args: perform actual completion
+
+## _carapace spec
+
+```go
+specCmd := &cobra.Command{
+    Use: "spec",
+    Run: func(cmd *cobra.Command, args []string) {
+        fmt.Fprint(cmd.OutOrStdout(), spec.Spec(targetCmd))
+    },
+}
+carapaceCmd.AddCommand(specCmd)
+```
+
+Running `myapp _carapace spec` outputs YAML spec for the entire command tree.
+
+## _carapace style
+
+```go
+styleCmd := &cobra.Command{
+    Use:  "style",
+    Args: cobra.ExactArgs(1),
+    Run:  func(cmd *cobra.Command, args []string) {},
+}
+carapaceCmd.AddCommand(styleCmd)
+
+styleSetCmd := &cobra.Command{
+    Use:  "set",
+    Args: cobra.MinimumNArgs(1),
+    Run: func(cmd *cobra.Command, args []string) {
+        for _, arg := range args {
+            if splitted := strings.SplitN(arg, "=", 2); len(splitted) == 2 {
+                if err := style.Set(splitted[0], splitted[1]); err != nil {
+                    fmt.Fprint(cmd.ErrOrStderr(), err.Error())
+                }
+            }
+        }
+    },
+}
+styleCmd.AddCommand(styleSetCmd)
+Carapace{styleSetCmd}.PositionalAnyCompletion(
+    ActionStyleConfig(),
+)
+```
+
+`_carapace style set` updates `styles.json` on disk. `_carapace style set key=value [key=value...]`.
+
+## Positional Completion on _carapace
+
+The `_carapace` command itself has completion for its arguments:
+
+```go
+Carapace{carapaceCmd}.PositionalCompletion(
+    ActionStyledValues("bash", "zsh", "fish", ...),  // shell names
+    ActionValues(targetCmd.Root().Name()),           // root command name
+)
+Carapace{carapaceCmd}.PositionalAnyCompletion(
+    ActionCallback(func(c Context) Action {
+        args := []string{"_carapace", "export", ""}
+        args = append(args, c.Args[2:]...)
+        args = append(args, c.Value)
+
+        executable, err := os.Executable()
+        if err != nil {
+            return ActionMessage(err.Error())
+        }
+        return ActionExecCommand(executable, args...)(func(output []byte) Action {
+            if string(output) == "" {
+                return ActionValues()
+            }
+            return ActionImport(output)
+        })
+    }),
+)
+```
+
+The `PositionalAnyCompletion` re-invokes the binary with the `export` shell to get completions for arbitrary arguments. This is the mechanism that enables `_carapace export` to work.
+
+## Standalone Mode
+
+```go
+if parentCmd.Annotations[annotation_standalone] == "true" {
+    parentCmd.RemoveCommand(cmd)
+}
+```
+
+When a command is in standalone mode (`annotation_standalone = "true"`), the `_carapace` subcommand is removed from the command tree. This prevents completion of the hidden carapace command itself.
+
+## Annotation Constants
+
+Defined in `carapace.go`:
+- `annotation_standalone` — marks a command as standalone (no `_carapace` subcommand)
+- `annotation_skip` — skips the command in certain operations
+
+## Re-invocation Flow
+
+```
+Shell invokes: myapp _carapace bash git branch --force
+    │
+    ├─ complete(git, ["bash", "git", "branch", "--force"])
+    │    └─ traverse(git, ["branch", "--force"])
+    │         └─ storage.getFlag(git, "force")
+    │              └─ action.Invoke(context).value("bash")
+    │
+    └─ myapp _carapace export git branch --force --force
+         └─ ActionImport(json) → re-invokes the export shell
+```
+
+The export shell re-invocation is used for subcommand completion to resolve nested command trees.
+
+## Gotchas
+
+- **Hidden subcommand visible with underscore prefix**: If `args[2]` starts with `_`, `cmd.Hidden = false` temporarily makes `_carapace` visible. This allows completion for `_carapace` itself.
+- **JSON export via ActionExecCommand**: The `PositionalAnyCompletion` on `_carapace` uses `ActionExecCommand` to re-invoke the binary with `export` shell and parse the JSON result back via `ActionImport`. This is the only path for nested subcommand completion.
+- **complete() log output**: `LOG.Printf("%#v", os.Args)` prints all invocations when `CARAPACE_LOG` is set, including the full argument list.
+- **Standalone removes _carapace**: In standalone mode, the `_carapace` subcommand is removed after the parent command is set up, so it doesn't appear in the completion candidates for the root command.
+
+## Related Skills
+
+- **references/traverse.md** — complete() dispatch and traverse()
+- **references/action.md** — ActionImport for parsing export JSON
+- **references/export.md** — the JSON wire format
+- **references/spec.md** — spec.Spec used by `_carapace spec`

--- a/skills/carapace-dev/references/conditionals.md
+++ b/skills/carapace-dev/references/conditionals.md
@@ -1,0 +1,144 @@
+# Carapace Library: Conditional Helpers
+
+Reference for [carapace](https://github.com/carapace-sh/carapace)'s conditional completion helpers in `pkg/condition/`.
+
+## Overview
+
+These helpers produce `func(carapace.Context) bool` predicates used with `Action.UnlessF()` or `Action.Unless()` to conditionally suppress or include completions based on runtime context.
+
+## Arch — GOARCH Filter
+
+```go
+func Arch(s ...string) func(c carapace.Context) bool {
+    return func(c carapace.Context) bool {
+        return slices.Contains(s, runtime.GOARCH)
+    }
+}
+```
+
+```go
+ActionValues("linux", "darwin", "windows").
+    UnlessF(condition.Arch("linux", "darwin"))
+```
+
+## Os — GOOS Filter
+
+```go
+func Os(s ...string) func(c carapace.Context) bool {
+    return func(c carapace.Context) bool {
+        return slices.Contains(s, runtime.GOOS)
+    }
+}
+```
+
+## Executable — PATH Lookup
+
+```go
+func Executable(s ...string) func(c carapace.Context) bool {
+    return func(c carapace.Context) bool {
+        for _, executable := range s {
+            if _, err := exec.LookPath(executable); err == nil {
+                return true
+            }
+        }
+        return false
+    }
+}
+```
+
+```go
+ActionValues("docker", "podman").
+    UnlessF(condition.Executable("docker"))
+```
+
+Note: Uses `exec.LookPath` directly instead of `Context.Command()`, so it uses the real PATH, not the sandbox's mocked environment.
+
+## File — File or Directory Existence
+
+```go
+func File(s string) func(c carapace.Context) bool {
+    return func(c carapace.Context) bool {
+        if _, err := os.Stat(s); err == nil {
+            return true
+        }
+        return false
+    }
+}
+```
+
+```go
+ActionValues("force", "interactive").
+    UnlessF(condition.File("/etc/myapp.conf"))
+```
+
+## CompletingPath — Path Prefix Detection
+
+```go
+func CompletingPath(c carapace.Context) bool {
+    return util.HasPathPrefix(c.Value)
+}
+```
+
+Returns true when `Context.Value` starts with `/`, `./`, `../`, or `~`.
+
+## CompletingPathS — Path with Separator
+
+```go
+func CompletingPathS(c carapace.Context) bool {
+    return CompletingPath(c) || strings.Contains(c.Value, "/")
+}
+```
+
+Like `CompletingPath` but also triggers when the value contains a `/` anywhere (not just as a prefix). Useful for completions where partial path segments are being completed.
+
+## Usage with Unless / UnlessF
+
+All conditionals are predicates for use with `Unless`:
+
+```go
+ActionCallback(func(c carapace.Context) carapace.Action {
+    if condition.Executable("docker")(c) {
+        return ActionValues("start", "stop", "rm")
+    }
+    return ActionMessage("docker not found")
+})
+```
+
+`UnlessF` applies the inverse:
+
+```go
+ActionValues("linux-amd64", "darwin-arm64").
+    UnlessF(condition.Arch("linux")).
+    UnlessF(condition.Os("windows"))
+```
+
+## As Modifiers
+
+Conditionals can also be composed inline:
+
+```go
+carapace.ActionValues("a", "b").
+    UnlessF(func(c carapace.Context) bool {
+        return runtime.GOOS == "windows"
+    })
+```
+
+## Future / Additional Helpers
+
+Additional conditionals may exist in the package (check `pkg/condition/*.go`). Common patterns not yet present but reasonable to add:
+
+- `Env(key, value)` — check environment variable
+- `FlagChanged(name)` — check if a flag was set
+- `HasPrefix(s)` — check if value has a prefix
+- `ToLower` — case conversion predicates
+
+## Gotchas
+
+- **Executable uses real PATH**: `exec.LookPath` reads the actual system PATH, not `Context.Env`. In sandbox tests, the real PATH is still used.
+- **File uses absolute paths**: `os.Stat` requires an absolute path. Use `Context.Abs()` to resolve relative paths first.
+- **No sandbox mocking for conditionals**: Unlike `Context.Command()`, conditionals directly call `os`, `exec`, `runtime` — no mocking via `CARAPACE_SANDBOX`.
+
+## Related Skills
+
+- **references/action.md** — Unless/UnlessF modifiers
+- **pkg/util/** — HasPathPrefix utility used by CompletingPath

--- a/skills/carapace-dev/references/config-env.md
+++ b/skills/carapace-dev/references/config-env.md
@@ -1,0 +1,176 @@
+# Carapace Library: Config & Environment
+
+Reference for [carapace](https://github.com/carapace-sh/carapace)'s runtime configuration — `styles.json` loading and CARAPACE_* environment variables.
+
+## styles.json — User Style Configuration
+
+`config.Load()` reads `$XDG_CONFIG_HOME/carapace/styles.json` (fallback: `~/.config/carapace/styles.json`):
+
+```json
+{
+  "style": {
+    "keyword": "blue bold",
+    "path":    "underline"
+  }
+}
+```
+
+The file maps style category names to style strings. Each registered style config struct (`config.RegisterStyle`) is a field on the `config.Styles` map. Field values are injected via reflection:
+
+```go
+config.RegisterStyle("style", &struct {
+    Keyword string `description:"keyword style"`
+    Path    string `description:"path style"`
+}{})
+```
+
+`config.Load()` unmarshals the JSON and sets struct fields by name match.
+
+## Config Loading Flow
+
+```
+config.Load()
+  └─ load("styles", config.Styles)
+       └─ xdg.UserConfigDir() → ~/.config (or $XDG_CONFIG_HOME)
+            └─ ReadFile ~/.config/carapace/styles.json
+                 └─ Unmarshal into map[name]map[field]value
+                      └─ reflect.ValueOf(s).Elem().FieldByName(k).SetString(v)
+```
+
+## CARAPACE_* Environment Variables
+
+All defined in `internal/env/env.go`:
+
+| Constant | Env Var | Purpose |
+|----------|---------|---------|
+| `CARAPACE_COLOR` | `CARAPACE_COLOR` | Enable color explicitly (0=disable) |
+| `CARAPACE_COMPLINE` | `CARAPACE_COMPLINE` | Raw completion line (cmd-clink) |
+| `CARAPACE_COVERDIR` | `CARAPACE_COVERDIR` | Coverage directory for sandbox tests |
+| `CARAPACE_DESCRIPTION_LENGTH` | `CARAPACE_DESCRIPTION_LENGTH` | Max description length (default 80) |
+| `CARAPACE_EXPERIMENTAL` | `CARAPACE_EXPERIMENTAL` | Enable experimental features |
+| `CARAPACE_HIDDEN` | `CARAPACE_HIDDEN` | Show hidden cmds/flags (1=exclude carapace, 2=include) |
+| `CARAPACE_LENIENT` | `CARAPACE_LENIENT` | Allow unknown flags |
+| `CARAPACE_LOG` | `CARAPACE_LOG` | Enable debug logging |
+| `CARAPACE_MATCH` | `CARAPACE_MATCH` | Match mode (e.g., `CASE_INSENSITIVE`) |
+| `CARAPACE_MERGEFLAGS` | `CARAPACE_MERGEFLAGS` | Merge shorthand/longhand flags into single tag |
+| `CARAPACE_NOSPACE` | `CARAPACE_NOSPACE` | Additional nospace suffixes |
+| `CARAPACE_SANDBOX` | `CARAPACE_SANDBOX` | JSON mock context for sandbox tests |
+| `CARAPACE_TOOLTIP` | `CARAPACE_TOOLTIP` | Enable tooltip style |
+| `CARAPACE_UNFILTERED` | `CARAPACE_UNFILTERED` | Skip prefix filtering |
+| `CARAPACE_ZSH_HASH_DIRS` | `CARAPACE_ZSH_HASH_DIRS` | Zsh hash directories |
+| `CLICOLOR` | `CLICOLOR` | Disable color (standard CLI convention) |
+| `NO_COLOR` | `NO_COLOR` | Disable color (standard NO_COLOR convention) |
+
+## Boolean Env Parsing
+
+```go
+func getBool(s string) bool {
+    switch os.Getenv(s) {
+    case "true", "1":
+        return true
+    default:
+        return false
+    }
+}
+```
+
+All boolean env helpers use this. "true" and "1" are truthy; everything else (including empty string) is falsy.
+
+## Hidden Mode
+
+```go
+const (
+    HIDDEN_NONE hidden = iota
+    HIDDEN_EXCLUDE_CARAPACE
+    HIDDEN_INCLUDE_CARAPACE
+)
+
+func Hidden() hidden {
+    switch parsed, _ := strconv.Atoi(os.Getenv(CARAPACE_HIDDEN)); parsed {
+    case 1:  return HIDDEN_EXCLUDE_CARAPACE
+    case 2:  return HIDDEN_INCLUDE_CARAPACE
+    default: return HIDDEN_NONE
+    }
+}
+```
+
+Integer env var: `0`/default = show normal, `1` = exclude `_carapace`, `2` = include all including hidden.
+
+## Sandbox Detection
+
+```go
+func Sandbox() (m *mock.Mock, err error) {
+    sandbox := os.Getenv(CARAPACE_SANDBOX)
+    if sandbox == "" || !isGoRun() {
+        return nil, errors.New("no sandbox")
+    }
+    err = json.Unmarshal([]byte(sandbox), &m)
+    return
+}
+
+func isGoRun() bool {
+    return strings.Contains(os.Args[0], "/go-build")
+}
+```
+
+Only activates under `go run` (not compiled binaries). Returns the unmarshaled `*mock.Mock`.
+
+## Logging
+
+`log.LOG` is a `*log.Logger` that writes to a file when `CARAPACE_LOG` is set:
+
+```go
+func init() {
+    if !env.Log() {
+        LOG = log.New(io.Discard, "", log.Flags())
+        return
+    }
+    tmpdir := fmt.Sprintf("%v/carapace", os.TempDir())
+    os.MkdirAll(tmpdir, os.ModePerm)
+    file := fmt.Sprintf("%v/%v.log", tmpdir, uid.Executable())
+    logfileWriter, _ := os.OpenFile(file, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
+    LOG = log.New(logfileWriter, ps.DetermineShell()+" ", log.Flags()|log.Lmsgprefix|log.Lmicroseconds)
+}
+```
+
+Log file: `/tmp/carapace/<executable>.log`. Prefix includes the detected shell name and microsecond timestamps.
+
+## LOG Usage
+
+```go
+LOG.Printf("executing PreRun for %#v with args %#v", cmd.Name(), args)
+```
+
+Conditional — no-op when `CARAPACE_LOG` is not set.
+
+## Color Disabled Logic
+
+```go
+func ColorDisabled() bool {
+    if v, ok := os.LookupEnv(CARAPACE_COLOR); ok {
+        return v == "0"
+    }
+    return getBool(NO_COLOR) || os.Getenv(CLICOLOR) == "0"
+}
+```
+
+Priority: explicit `CARAPACE_COLOR=0` > `NO_COLOR` > `CLICOLOR=0`. Explicit `CARAPACE_COLOR=1` enables even when `NO_COLOR` is set.
+
+## Description Length
+
+```go
+func DescriptionLength() int {
+    if parsed, err := strconv.Atoi(os.Getenv(CARAPACE_DESCRIPTION_LENGTH)); err == nil && parsed > 0 {
+        return parsed
+    }
+    return 80
+}
+```
+
+Integer env var with default 80.
+
+## Related Skills
+
+- **references/style.md** — style system that uses config values
+- **references/sandbox.md** — CARAPACE_SANDBOX injection
+- **references/cache.md** — CARAPACE_COVERDIR for coverage

--- a/skills/carapace-dev/references/export.md
+++ b/skills/carapace-dev/references/export.md
@@ -1,0 +1,160 @@
+# Carapace Library: Export Format
+
+Reference for [carapace](https://github.com/carapace-sh/carapace)'s JSON wire format in `internal/export/`.
+
+## Export Struct
+
+```go
+type Export struct {
+    Version string       `json:"version"`
+    common.Meta
+    Values common.RawValues `json:"values"`
+}
+```
+
+The universal JSON representation of a completed action. Contains:
+- **Version**: carapace library version from `debug.BuildInfo`
+- **Meta**: messages, nospace set, usage hint, queries
+- **Values**: sorted list of `RawValue` entries
+
+## MarshalJSON
+
+```go
+func (e Export) MarshalJSON() ([]byte, error) {
+    sort.Sort(common.ByValue(e.Values))
+    return json.Marshal(&struct {
+        Version string `json:"version"`
+        common.Meta
+        Values common.RawValues `json:"values"`
+    }{
+        Version: version(),
+        Meta:    e.Meta,
+        Values:  e.Values,
+    })
+}
+```
+
+Always re-sorts values by `Value` before serializing. Values must be sorted for deterministic output.
+
+## Version Lookup
+
+```go
+func version() string {
+    if info, ok := debug.ReadBuildInfo(); ok {
+        for _, dep := range info.Deps {
+            if dep.Path == "github.com/carapace-sh/carapace" {
+                return dep.Version
+            }
+        }
+    }
+    return "unknown"
+}
+```
+
+Reads `debug.BuildInfo` to find the carapace library version. Returns `"unknown"` if not available (e.g., in tests without module info).
+
+## Usage in Cache
+
+Cache files store `export.Export` JSON. The `common.Meta` includes messages and nospace state, so cached completions restore the full completion context:
+
+```go
+// cache.LoadE returns *export.Export
+if cached, err := cache.LoadE(cacheFile, timeout); err == nil {
+    return Action{meta: cached.Meta, rawValues: cached.Values}
+}
+```
+
+## Usage in Sandbox
+
+Sandbox's `run.invoke()` converts an `InvokedAction` to JSON using the export format:
+
+```go
+func (r run) invoke(a carapace.Action) string {
+    meta, rawValues := common.FromInvokedAction(a.Invoke(r.context))
+    rawValues = rawValues.FilterPrefix(r.context.Value)
+    sort.Sort(common.ByValue(rawValues))
+
+    m, _ := json.MarshalIndent(export.Export{
+        Meta:   meta,
+        Values: rawValues,
+    }, "", "  ")
+    return string(m)
+}
+```
+
+The sandbox JSON is compared with `assert.Equal` for test assertions.
+
+## Usage in ActionImport
+
+`ActionImport` parses JSON back into an action:
+
+```go
+func ActionImport(output string) Action {
+    var e export.Export
+    if err := json.Unmarshal([]byte(output), &e); err != nil {
+        return ActionMessage(err.Error())
+    }
+    return Action{meta: e.Meta, rawValues: e.Values}
+}
+```
+
+Used by the `_carapace export` subcommand to re-import completions.
+
+## The export Shell
+
+The `export` shell target in `complete()` re-invokes the `_carapace` command with `export` as the shell argument:
+
+```go
+if shell == "export" {
+    // Re-invokes as: myapp _carapace export <root-cmd> <args...>
+    // Outputs JSON to stdout
+}
+```
+
+This enables subcommand completion to work across process boundaries — the parent process re-invokes itself with the `export` shell to resolve nested subcommand completions, then parses the JSON.
+
+## RawValue Structure
+
+`common.RawValue` is the unit of completion data:
+
+```go
+type RawValue struct {
+    Value       string
+    Display     string
+    Kind        rawValueKind
+    Style       string
+    Tag         string
+    Uid         string
+    Description string
+}
+```
+
+- **Value**: inserted text (what the shell actually receives)
+- **Display**: shown text (may differ from Value for placeholders/prefixes)
+- **Kind**: type indicator (plain, path, keyword, etc.)
+- **Style**: ANSI style string
+- **Tag**: grouping tag for filtering
+- **Uid**: unique identifier
+- **Description**: shown description text
+
+## Meta Structure
+
+```go
+type Meta struct {
+    Messages Messages
+    Nospace  SuffixMatcher
+    Usage    string
+    Queries  []string
+}
+```
+
+- **Messages**: info/warning messages to display
+- **Nospace**: characters after which the shell should NOT add a trailing space
+- **Usage**: usage hint string
+- **Queries**: query metadata for UID resolution
+
+## Related Skills
+
+- **references/cache.md** — export.Export is the cache file format
+- **references/sandbox.md** — sandbox uses export for test assertions
+- **references/action.md** — Action → InvokedAction → export cycle

--- a/skills/carapace-dev/references/mock.md
+++ b/skills/carapace-dev/references/mock.md
@@ -1,0 +1,136 @@
+# Carapace Library: Mock System
+
+Reference for [carapace](https://github.com/carapace-sh/carapace)'s mock system in `internal/mock/` used by sandbox tests.
+
+## Mock Struct
+
+```go
+type Mock struct {
+    Dir     string
+    Replies map[string]string
+}
+```
+
+The mock holds:
+- **Dir**: the sandbox temp directory path
+- **Replies**: a map of JSON-serialized command args → output strings
+
+## Directory Structure
+
+```
+<tempdir>/carapace-sandbox_<testname>_xxxxx/
+├── cache/   ← mock.CacheDir()
+└── work/    ← mock.WorkDir()
+```
+
+## Mock Methods
+
+```go
+func (m Mock) CacheDir() string {
+    return m.Dir + "/cache/"
+}
+
+func (m Mock) WorkDir() string {
+    return m.Dir + "/work/"
+}
+```
+
+## NewMock — Create a Mock
+
+```go
+func NewMock(t t) *Mock {
+    tempDir, err := os.MkdirTemp(os.TempDir(), fmt.Sprintf("carapace-sandbox_%v_", t.Name()))
+    if err != nil {
+        t.Fatal("failed to create sandbox dir: " + err.Error())
+    }
+
+    m := &Mock{
+        Dir:     tempDir,
+        Replies: make(map[string]string),
+    }
+    if err := os.Mkdir(m.CacheDir(), os.ModePerm); err != nil {
+        t.Fatal("failed to create sandbox cache dir: " + err.Error())
+    }
+    if err := os.Mkdir(m.WorkDir(), os.ModePerm); err != nil {
+        t.Fatal("failed to create sandbox work dir: " + err.Error())
+    }
+    return m
+}
+```
+
+Creates the temp directory and `cache/` and `work/` subdirectories. Uses `t.Fatal` for error reporting (idiomatic Go test pattern).
+
+## Sandbox Integration
+
+The mock is JSON-marshaled and injected as `CARAPACE_SANDBOX`:
+
+```go
+func (s *Sandbox) Run(args ...string) run {
+    m, _ := json.Marshal(s.mock)
+    r := run{
+        t:       s.t,
+        id:      string(m),
+        dir:     s.mock.WorkDir(),
+        context: s.NewContext(args...),
+    }
+
+    r.actual = carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+        b, err := json.Marshal(s.mock)
+        if err != nil {
+            return carapace.ActionMessage(err.Error())
+        }
+        c.Setenv("CARAPACE_SANDBOX", string(b))
+        return carapace.ActionExecute(s.cmdF()).Invoke(c).ToA()
+    }).Invoke(r.context).ToA()
+
+    return r
+}
+```
+
+`CARAPACE_SANDBOX` is read by `env.Sandbox()` to get the mock directory and replies.
+
+## Reply Mechanism
+
+```go
+func (s *Sandbox) Reply(args ...string) reply {
+    m, _ := json.Marshal(args)
+    return reply{s, string(m)}
+}
+
+func (r reply) With(s string) {
+    r.mock.Replies[r.call] = s
+}
+```
+
+Command arguments are JSON-serialized as the map key (e.g., `["git", "remote"]` → `"[\"git\",\"remote\"]"`). The output string is stored as the value.
+
+At invocation time, `Context.Command()` checks `env.Sandbox()` for mocked replies.
+
+## The t Interface
+
+```go
+type t interface {
+    Name() string
+    Fatal(...any)
+}
+```
+
+Minimal interface compatible with `*testing.T`. Allows the mock to work with any testing framework that provides `Name()` and `Fatal()`.
+
+## How Context.Command() Uses Mock
+
+`Context.Command()` (in `context.go`) checks for `CARAPACE_SANDBOX` and uses mocked replies when available. The actual implementation in `Context.Command()` reads `env.Sandbox()` and looks up the command key in `m.Replies`.
+
+## Gotchas
+
+- **JSON-serialized keys**: `s.Reply("git", "remote")` stores under `"[\"git\",\"remote\"]"`, not the plain string. Exact match required.
+- **Temp directory cleanup**: `s.remove()` in `sandbox.go` only removes directories under `os.TempDir()`. If `s.Keep()` was called, the directory is retained.
+- **No mocking for exec.LookPath**: `condition.Executable()` uses `exec.LookPath` directly, bypassing the sandbox mock. Only `Context.Command()` is mocked.
+- **No mocking for os.Stat**: File existence checks (`condition.File()`) use real filesystem, not sandbox files. Use `s.Files()` to create real files in the sandbox's `work/` directory instead.
+- **Cache dir in mock**: Each mock has its own `cache/` subdirectory. `s.ClearCache()` removes it.
+
+## Related Skills
+
+- **references/sandbox.md** — how mock integrates into the sandbox
+- **internal/env/** — env.Sandbox() reads CARAPACE_SANDBOX
+- **pkg/sandbox/** — sandbox uses mock.NewMock

--- a/skills/carapace-dev/references/sandbox.md
+++ b/skills/carapace-dev/references/sandbox.md
@@ -1,0 +1,154 @@
+# Carapace Library: Sandbox Testing
+
+Reference for [carapace](https://github.com/carapace-sh/carapace)'s sandbox testing harness in `pkg/sandbox/`.
+
+## Overview
+
+The sandbox runs completion tests in an isolated subprocess with a temporary directory, mocked environment, and controlled command replies. It avoids conflicts with the global `storage` map by running each test as a separate process.
+
+## Entry Points
+
+### Command — test a cobra command directly
+
+```go
+sandbox.Command(t, func() *cobra.Command {
+    cmd := &cobra.Command{Use: "myapp"}
+    carapace.Gen(cmd).PositionalCompletion(carapace.ActionValues("a", "b"))
+    return cmd
+})(func(s *sandbox.Sandbox) {
+    s.Files("test.txt", "content")
+    s.Run("", "").Expect(carapace.ActionValues("a", "b"))
+})
+```
+
+### Package — test via `go run` (integration)
+
+```go
+sandbox.Package(t, "example")(func(s *sandbox.Sandbox) {
+    s.Run("myapp", "subcmd", "").Expect(carapace.ActionValues("x", "y"))
+})
+```
+
+### Action — test a standalone action
+
+```go
+sandbox.Action(t, func() carapace.Action {
+    return carapace.ActionValues("a", "b", "c").StyleF(style.ForKeyword)
+})(func(s *sandbox.Sandbox) {
+    s.Run("").Expect(carapace.ActionValues("a", "b", "c").StyleF(style.ForKeyword))
+})
+```
+
+## Sandbox Setup
+
+`newSandbox(t, cmdF)` creates:
+
+- A `*mock.Mock` with a temp directory at `os.TempDir()/carapace-sandbox_<testname>_`
+- `cache/` subdirectory for cache tests
+- `work/` subdirectory for file tests
+- A `*testing.T` reference for error reporting
+
+The sandbox directory is auto-removed on test completion unless `s.Keep()` is called.
+
+## Files — Create Test Files
+
+```go
+s.Files(
+    "file1.txt", "content of file1.txt",
+    "dir1/file2.md", "content of file2.md",
+)
+```
+
+Files are created relative to the sandbox's `work/` directory. Filenames with `..` or leading `/` are rejected.
+
+## Env — Set Environment Variables
+
+```go
+s.Env("CARAPACE_UNFILTERED", "true")
+s.Env("HOME", "/tmp/testhome")
+```
+
+Set on the `Context` passed to action invocation.
+
+## Reply — Mock Command Output
+
+```go
+s.Reply("git", "remote").With("origin\nfork")
+s.Reply("docker", "ps", "-q").With("abc123\ndef456")
+```
+
+Mocks `Context.Command()` output. Calls are JSON-serialized as the map key (`["git", "remote"]`). Only works with `Context.Command()`, not raw `exec.Command`.
+
+## Run — Execute Completion
+
+```go
+s.Run(args ...string) run
+```
+
+Creates a `Context` from the args (last arg = `Value`, rest = `Args`), injects `CARAPACE_SANDBOX` with the mock JSON, and executes `ActionExecute(cmdF())` via the sandbox.
+
+Returns a `run` value with `Expect`, `ExpectNot`, and `Output` methods.
+
+## Expect — Assert Output
+
+```go
+s.Run("", "").Expect(carapace.ActionValues("a", "b"))
+s.Run("", "").ExpectNot(carapace.ActionValues("x"))
+```
+
+Serializes both the expected and actual actions to JSON via `export.Export` and compares with `assert.Equal`. The test is named after the args tuple (e.g., `run["",""]`).
+
+## ClearCache — Clear Cache Between Tests
+
+```go
+s.ClearCache()
+```
+
+Removes the sandbox's `cache/` directory. Use between subtests to ensure cache-dependent tests don't interfere.
+
+## Sandbox Env Vars
+
+The sandbox sets `CARAPACE_SANDBOX` containing a JSON-encoded `*mock.Mock`:
+
+```json
+{
+  "Dir": "/tmp/carapace-sandbox_testname_xxxxx",
+  "Replies": { "[\"git\",\"remote\"]": "origin\nfork" }
+}
+```
+
+`env.Sandbox()` reads and unmarshals this variable. The `isGoRun()` check ensures sandbox mode only activates under `go run` (not compiled binaries).
+
+## Architecture
+
+```
+sandbox.Command/Package/Action
+  └─ newSandbox
+       └─ mock.NewMock  → creates temp dir, cache/, work/
+  └─ defer s.remove()   → cleanup unless s.Keep()
+  └─ f(&sandbox)       → test body
+       ├─ s.Files()
+       ├─ s.Reply().With()
+       ├─ s.Env()
+       └─ s.Run(args...)
+            ├─ s.NewContext(args...)
+            │    └─ Context{Dir: mock.WorkDir(), Env: s.env}
+            └─ ActionExecute(cmdF())
+                 └─ ActionCallback
+                      └─ sets CARAPACE_SANDBOX=json(mock)
+                           └─ env.Sandbox() in cache.File()
+```
+
+## Gotchas
+
+- **No parallel tests**: `t.Parallel()` is explicitly TODO-commented — storage mutations make concurrent tests unsafe.
+- **SANDBOX only under go run**: `env.Sandbox()` checks `isGoRun()` which matches `/go-build` in `os.Args[0]`. Compiled binaries skip sandbox mode.
+- **Reply keys are JSON arrays**: `s.Reply("git", "remote")` serializes to `"[\"git\",\"remote\"]"` as the map key. Exact match required.
+- **Cache keys include file:line**: `Action.Cache()` uses `runtime.Caller(1)` — moving a `.Cache()` call changes the key.
+- **`s.Keep()` for debugging**: Call before the test body to retain the temp directory for inspection.
+
+## Related Skills
+
+- **references/action.md** — Action API tested via sandbox
+- **references/cache.md** — cache integration in sandbox
+- **pkg/assert/** — assertion library used by `Expect`

--- a/skills/carapace-dev/references/spec.md
+++ b/skills/carapace-dev/references/spec.md
@@ -1,0 +1,142 @@
+# Carapace Library: Spec Generation
+
+Reference for [carapace](https://github.com/carapace-sh/carapace)'s YAML spec generation from cobra commands in `internal/spec/`.
+
+## spec.Spec — Generate YAML from a Command
+
+```go
+func Spec(cmd *cobra.Command) string {
+    m, _ := yaml.Marshal(command(cmd))
+    return "# yaml-language-server: $schema=https://carapace.sh/schemas/command.json\n" + string(m)
+}
+```
+
+Writes the command tree as YAML. Prepends a YAML language server comment for IDE schema validation.
+
+## Command Struct
+
+```go
+type Command struct {
+    Name            string            `yaml:"name"`
+    Aliases         []string          `yaml:"aliases,omitempty"`
+    Description     string            `yaml:"description,omitempty"`
+    Group           string            `yaml:"group,omitempty"`
+    Hidden          bool              `yaml:"hidden,omitempty"`
+    ExclusiveFlags  [][]string        `yaml:"exclusiveflags,omitempty"`
+    Flags           map[string]string `yaml:"flags,omitempty"`
+    PersistentFlags map[string]string `yaml:"persistentflags,omitempty"`
+    Completion      struct {
+        Flag          map[string][]string `yaml:"flag,omitempty"`
+        Positional    [][]string          `yaml:"positional,omitempty"`
+        PositionalAny []string            `yaml:"positionalany,omitempty"`
+        Dash          [][]string          `yaml:"dash,omitempty"`
+        DashAny       []string            `yaml:"dashany,omitempty"`
+    } `yaml:"completion,omitempty"`
+    Commands []Command `yaml:"commands,omitempty"`
+}
+```
+
+Flags map key is the flag definition string (e.g., `-v, --verbose!*?`) and value is the usage string.
+
+## Recursive Command Tree
+
+```go
+func command(cmd *cobra.Command) Command {
+    c := Command{
+        Name:            cmd.Use,
+        Description:     cmd.Short,
+        Aliases:         cmd.Aliases,
+        Group:           cmd.GroupID,
+        Hidden:          cmd.Hidden,
+        Flags:           make(map[string]string),
+        PersistentFlags: make(map[string]string),
+        Commands:        make([]Command, 0),
+    }
+
+    cmd.LocalFlags().VisitAll(func(flag *pflag.Flag) {
+        if cmd.PersistentFlags().Lookup(flag.Name) != nil {
+            return
+        }
+        f := pflagfork.Flag{Flag: flag}
+        c.Flags[f.Definition()] = f.Usage
+    })
+
+    cmd.PersistentFlags().VisitAll(func(flag *pflag.Flag) {
+        f := pflagfork.Flag{Flag: flag}
+        c.PersistentFlags[f.Definition()] = f.Usage
+    })
+
+    for _, subcmd := range cmd.Commands() {
+        if subcmd.Name() != "_carapace" && subcmd.Deprecated == "" {
+            c.Commands = append(c.Commands, command(subcmd))
+        }
+    }
+    return c
+}
+```
+
+Recursively processes the command tree, skipping:
+- The `_carapace` subcommand (auto-generated)
+- Deprecated commands (`cmd.Deprecated != ""`)
+
+## pflagfork.Flag.Definition
+
+The `Definition()` method produces a human-readable flag string used as the map key in the YAML:
+
+```
+f.Definition() // e.g., "-v, --verbose!*?" or "-f, --file"
+```
+
+Format: `-shorthand, --name<optarg>?` where:
+- `!` = required (no `NoOptDefVal`)
+- `*` = optarg (`NoOptDefVal != ""`)
+- `?` = hidden flag
+
+## Flag Field Extraction
+
+Uses `pflagfork.Flag` to wrap the raw `*pflag.Flag` and read unexported fields via reflection:
+
+```go
+f := pflagfork.Flag{Flag: flag}
+c.Flags[f.Definition()] = f.Usage
+```
+
+The `pflagfork.Flag` wrapper is the same type used by `traverse()` — it provides `Mode()`, `Nargs()`, `OptargDelimiter()`, `Definition()`, and other methods that read unexported pflag fields.
+
+## Usage in command.go
+
+`carapace.Gen(cmd)` registers the `_carapace spec` subcommand:
+
+```go
+specCmd := &cobra.Command{
+    Use: "spec",
+    Run: func(cmd *cobra.Command, args []string) {
+        fmt.Fprint(cmd.OutOrStdout(), spec.Spec(targetCmd))
+    },
+}
+carapaceCmd.AddCommand(specCmd)
+```
+
+Running `myapp _carapace spec` outputs the YAML spec for the entire command tree.
+
+## carapace-spec (Separate Module)
+
+The `carapace-spec` module (in carapace-bin) has a separate, slim `internal/pflagfork` for code generation — it only reads flag metadata, no parsing logic. The spec generation reads the same fields that `traverse()` uses at runtime.
+
+## YAML Schema
+
+The generated YAML conforms to the JSON schema at `https://carapace.sh/schemas/command.json`. The YAML-LSP comment at the top enables IDE validation in editors like VS Code with the YAML extension.
+
+## Gotchas
+
+- **Completion fields are empty**: The `Completion` struct in the YAML type is for carapace-bin spec files, not for generated specs from running commands. Generated specs only include `Name`, `Aliases`, `Description`, `Group`, `Hidden`, `Flags`, `PersistentFlags`, and `Commands`.
+- **ExclusiveFlags not populated**: The `ExclusiveFlags` field exists in the struct but is always empty in the generated output (TODO).
+- **Hidden flags via `?`**: The `Definition()` suffix `?` indicates a hidden flag. Not all flag types support hidden.
+- **Skip _carapace**: The spec command itself is excluded from the tree to avoid polluting the generated spec.
+- **No annotation of completion actions**: The generated YAML does not include completion actions — it's a structural skeleton only. carapace-bin uses this as a starting point for manual spec authoring.
+
+## Related Skills
+
+- **references/traverse.md** — pflagfork used during runtime traversal
+- **references/pflag.md** — pflagfork flag metadata fields
+- **carapace skill** — user-facing spec authoring (in carapace-bin)

--- a/skills/carapace-dev/references/storage.md
+++ b/skills/carapace-dev/references/storage.md
@@ -1,0 +1,153 @@
+# Carapace Library: Storage & Hooks Internals
+
+Reference for [carapace](https://github.com/carapace-sh/carapace)'s per-command completion storage — the global map, mutex protection, registration API, and PreRun/PreInvoke chains.
+
+## The entry Struct
+
+Every cobra command registered with `carapace.Gen()` gets an `entry` stored in a package-level `map[*cobra.Command]*entry`:
+
+```go
+type entry struct {
+    flag          ActionMap
+    flagMutex     sync.RWMutex
+    positional    []Action
+    positionalAny *Action
+    dash          []Action
+    dashAny       *Action
+    preinvoke     func(cmd *cobra.Command, flag *pflag.Flag, action Action) Action
+    prerun        func(cmd *cobra.Command, args []string)
+    bridged       bool
+    initialized   bool
+}
+```
+
+The storage map is private (`_storage`) with access routed through methods.
+
+## Global Storage Map
+
+```go
+var storageMutex sync.RWMutex
+
+func (s _storage) get(cmd *cobra.Command) *entry {
+    storageMutex.RLock()
+    e, ok := s[cmd]
+    storageMutex.RUnlock()
+
+    if !ok {
+        storageMutex.Lock()
+        defer storageMutex.Unlock()
+        if e, ok = s[cmd]; !ok {
+            e = &entry{}
+            s[cmd] = e
+        }
+    }
+    return e
+}
+```
+
+Double-checked locking: read-lock first, then write-lock only if the entry doesn't exist. This avoids locking on every access after warm-up.
+
+## Registration API
+
+`carapace.Gen(cmd)` returns a `Carapace` wrapper that provides the registration chain:
+
+```go
+type Carapace struct{ *cobra.Command }
+
+func (c Carapace) FlagCompletion(actions ActionMap) Carapace
+func (c Carapace) PositionalCompletion(actions ...Action) Carapace
+func (c Carapace) PositionalAnyCompletion(action Action) Carapace
+func (c Carapace) DashCompletion(actions ...Action) Carapace
+func (c Carapace) DashAnyCompletion(action Action) Carapace
+func (c Carapace) PreRun(fn func(cmd *cobra.Command, args []string)) Carapace
+func (c Carapace) PreInvoke(fn func(cmd *cobra.Command, flag *pflag.Flag, action Action) Action) Carapace
+```
+
+Each method calls `storage.get(cmd)` and mutates the corresponding entry field, protected by the per-entry `flagMutex` for flag actions.
+
+## PreRun — Before Traversal
+
+Executed in `storage.preRun()` before `traverse()` walks the command tree. Use for dynamically adding/removing subcommands or flags:
+
+```go
+carapace.Gen(rootCmd).PreRun(func(cmd *cobra.Command, args []string) {
+    if pluginEnabled {
+        cmd.AddCommand(pluginCommand)
+    }
+})
+```
+
+Called from `complete()` before any argument parsing or traversal.
+
+## PreInvoke — Before Action Invocation
+
+Executed for every action resolution (flag or positional) in `storage.preinvoke()`. Chains from child command to parent, so a PreInvoke on the root command affects all subcommands:
+
+```go
+carapace.Gen(rootCmd).PreInvoke(func(cmd *cobra.Command, flag *pflag.Flag, action carapace.Action) carapace.Action {
+    if flag != nil && flag.Name == "chdir" && cmd.Flag("chdir").Changed {
+        return action.Chdir(cmd.Flag("chdir").Value.String())
+    }
+    return action
+})
+```
+
+The `flag` parameter is `nil` for positional arguments. The chain runs after `traverse()` has classified the argument but before the action callback is executed.
+
+## Flag Lookup
+
+`storage.getFlag(cmd, name)` looks up a flag action, checking parent commands recursively:
+
+```go
+func (s _storage) getFlag(cmd *cobra.Command, name string) Action {
+    if flag := cmd.LocalFlags().Lookup(name); flag == nil && cmd.HasParent() {
+        return s.getFlag(cmd.Parent(), name)
+    } else {
+        entry := s.get(cmd)
+        entry.flagMutex.RLock()
+        defer entry.flagMutex.RUnlock()
+
+        flagAction, ok := entry.flag[name]
+        if !ok {
+            if f, ok := cmd.GetFlagCompletionFunc(name); ok {
+                flagAction = ActionCobra(f)
+            }
+        }
+        a := s.preinvoke(cmd, flag, flagAction)
+        return ActionCallback(func(c Context) Action {
+            invoked := a.Invoke(c)
+            if invoked.action.meta.Usage == "" {
+                invoked.action.meta.Usage = flag.Usage
+            }
+            return invoked.ToA()
+        })
+    }
+}
+```
+
+Falls back to cobra's native `GetFlagCompletionFunc` if no carapace action is registered.
+
+## Positional Lookup
+
+`storage.getPositional(cmd, index)` and `storage.hasPositional(cmd, index)` handle both normal and `--` (dash) positionals. Dash positionals use a separate array (`entry.dash`/`entry.dashAny`) activated when `common.IsDash(cmd)` returns true.
+
+## Validation
+
+`storage.check()` iterates all stored flag names and verifies each one exists on the command's `LocalFlags()`. Called by `carapace.Test()`. Reports unknown flags with `uid.Command(cmd)` as the context.
+
+## Bridge Integration
+
+`storage.bridge(cmd)` wires cobra's native completion functions (`ValidArgsFunction`, `RegisterFlagCompletionFunc`) via `cobra.OnInitialize()`. Called lazily on first completion request. Uses a separate `bridgeMutex` to prevent concurrent initialization.
+
+## Gotchas
+
+- **Global map**: `_storage` is a package-level global. Tests that register completions in parallel (`t.Parallel()`) will conflict. Sandbox tests run in subprocesses to avoid this.
+- **Per-entry mutex**: Flag actions use `entry.flagMutex.RLock()`, but positional/dash actions have no mutex. This is safe because positional registration is single-threaded after init.
+- **Cache keys from caller location**: `Action.Cache()` uses `runtime.Caller(1)` as the cache key base. Moving a `.Cache()` call to a different file:line changes the cache key and invalidates existing cache entries.
+- **PreInvoke chain order**: PreInvoke chains from child → parent. A PreInvoke on the root command runs first, then each intermediate command's PreInvoke, then the target command's PreInvoke.
+- **PreRun runs before Traversal**: `preRun()` is called from `complete()` before `traverse()`, so any command structure changes (added subcommands, flags) are visible to traversal.
+
+## Related Skills
+
+- **references/traverse.md** — how storage feeds into the traversal decision tree
+- **references/action.md** — the Action API that storage returns

--- a/skills/carapace-dev/references/uid.md
+++ b/skills/carapace-dev/references/uid.md
@@ -1,0 +1,172 @@
+# Carapace Library: UID System
+
+Reference for [carapace](https://github.com/carapace-sh/carapace)'s URL-based unique identifiers in `pkg/uid/`.
+
+## Overview
+
+UIDs are `url.URL` values with scheme `cmd` or `file`, providing stable, globally unique identifiers for commands and flags. They are used in cache key derivation, error messages, and debugging output.
+
+## URL Structure
+
+```go
+// Command UID
+cmd://rootcmd/subcmd?flag=flagname
+
+// Example: git branch
+cmd://git/branch
+
+// Flag: git branch --force
+cmd://git/branch?flag=force
+```
+
+- **Scheme**: `cmd` for commands, `file` for files (used in `Action.Uid()`)
+- **Host**: root command name
+- **Path**: subcommand path (slash-separated ancestors)
+- **Query**: `flag=<name>` for flag UIDs
+
+## uid.Command
+
+```go
+func Command(cmd *cobra.Command) *url.URL {
+    path := []string{cmd.Name()}
+    for parent := cmd.Parent(); parent != nil; parent = parent.Parent() {
+        path = append(path, url.PathEscape(parent.Name()))
+    }
+    reverse(path)
+    return &url.URL{
+        Scheme: "cmd",
+        Host:   path[0],
+        Path:   strings.Join(path[1:], "/"),
+    }
+}
+```
+
+Builds the UID by walking up the cobra parent chain. The root command is always the host.
+
+## uid.Flag
+
+```go
+var mLocalFlags sync.Mutex
+
+func Flag(cmd *cobra.Command, flag *pflagfork.Flag) *url.URL {
+    mLocalFlags.Lock()
+    defer mLocalFlags.Unlock()
+    return flagRecursive(cmd, flag)
+}
+
+func flagRecursive(cmd *cobra.Command, flag *pflagfork.Flag) *url.URL {
+    _ = cmd.LocalFlags() // Force flag merge; not thread-safe internally
+
+    if cmd.LocalFlags().Lookup(flag.Name) == nil && cmd.HasParent() {
+        return flagRecursive(cmd.Parent(), flag)
+    }
+    uid := Command(cmd)
+    values := uid.Query()
+    values.Set("flag", flag.Name)
+    uid.RawQuery = values.Encode()
+    return uid
+}
+```
+
+The mutex is necessary because `cmd.LocalFlags()` calls `mergePersistentFlags()` internally which is not thread-safe. The lock is held for the entire recursive traversal to prevent concurrent modification.
+
+## uid.UidF — Experimental UID Function
+
+```go
+func UidF(scheme, host string, opts ...string) func(v string, uc Context) (*url.URL, error) {
+    return func(v string, uc Context) (*url.URL, error) {
+        uid := &url.URL{
+            Scheme: scheme,
+            Host:   url.PathEscape(host),
+            Path:   PathEscape(v),
+        }
+        if len(opts) > 0 {
+            values := uid.Query()
+            for i := 0; i < len(opts); i += 2 {
+                if opts[i+1] != "" {
+                    values.Set(opts[i], opts[i+1])
+                }
+            }
+            uid.RawQuery = values.Encode()
+        }
+        return uid, nil
+    }
+}
+```
+
+Used by `Action.Uid()` and `Action.UidF()`. Takes alternating key-value opts (e.g., `"flag", "name", "group", "build"`). Empty values are skipped.
+
+## PathEscape
+
+```go
+func PathEscape(s string) string {
+    s = strings.ReplaceAll(s, "/", "-")
+    s = url.PathEscape(s)
+    return s
+}
+```
+
+Replaces `/` with `-` before escaping, since `/` is the path separator in the UID format. This allows values containing slashes (e.g., file paths) to be encoded as part of the path.
+
+## uid.Map — Testing Helper
+
+```go
+func Map(uids ...string) func(s string) (*url.URL, error) {
+    return func(s string) (*url.URL, error) {
+        for i := 0; i < len(uids); i += 2 {
+            if uids[i] == s {
+                return url.Parse(uids[i+1])
+            }
+        }
+        return &url.URL{}, nil
+    }
+}
+```
+
+Maps static values to UIDs for deterministic testing. Returns an empty UID for unmatched values.
+
+## uid.Executable
+
+```go
+func Executable() string {
+    executable, err := os.Executable()
+    if err != nil {
+        return "echo" // safe fallback
+    }
+    switch base := filepath.Base(executable); base {
+    case "cmd.test":
+        return "example" // for `go test -v ./...`
+    case "ld-musl-x86_64.so.1":
+        return filepath.Base(os.Args[0]) // alpine container workaround
+    default:
+        return base
+    }
+}
+```
+
+Used as the cache directory name component. Special-cases test binaries and Alpine's musl loader.
+
+## Context Interface
+
+```go
+type Context interface {
+    Abs(s string) (string, error)
+    Getenv(key string) string
+    LookupEnv(key string) (string, bool)
+}
+```
+
+Passed to `UidF` functions at invocation time. Implemented by `carapace.Context`.
+
+## Gotchas
+
+- **mLocalFlags mutex**: `cmd.LocalFlags()` is not thread-safe internally. The mutex protects the entire recursive traversal. A recent fix (commit 324b32b) addressed a race condition by holding the mutex during recursion.
+- **PathEscape converts `/` to `-`**: A value like `users/admin` becomes `users-admin` in the UID path. This is necessary because `/` is the path separator.
+- **Empty UID for unmatched Map values**: `uid.Map()` returns `&url.URL{}` for values not in the map, not an error.
+- **cmd.test → example**: During `go test`, `os.Executable()` returns the test binary name containing `.test`. The `cmd.test` case maps this to `example` for consistency with the integration test binary name.
+
+## Related Skills
+
+- **references/action.md** — Uid/UidF modifiers on Action
+- **references/storage.md** — where uid.Command is used for error reporting
+- **references/cache.md** — cache key derivation uses uid.Executable


### PR DESCRIPTION
Add missing documentation for library-internal topics: storage/hooks,
sandbox testing, Batch parallel invocation, cache system, UID identifiers,
config/env, spec YAML generation, export format, conditionals, command
CLI, and mock system. Update SKILL.md routing table and quick guide.
