### PR TITLE
add bash composite skill with 5 in-depth reference docs

### DIFF
--- a/skills/bash/SKILL.md
+++ b/skills/bash/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: bash
+description: >
+  Use when working with bash shell internals — programmable completion, Readline,
+  quoting/expansion, execution model, startup files, prompt hooks, or bash-completion
+  helpers. Triggers on: "bash", "bash completion", "bash readline", "bash quoting",
+  "bash expansion", "bash startup", "bash prompt", "COMP_WORDBREAKS", "COMPREPLY",
+  "complete builtin", "compgen", "compopt", "bash-completion", "inputrc", "bind builtin".
+user-invocable: true
+---
+
+# Bash Shell In-Depth Reference
+
+Comprehensive reference for bash shell internals, with emphasis on the completion system and how external tools hook into it.
+
+## Sub-Resources
+
+Load the reference that matches your task. When in doubt, load multiple references.
+
+| Keywords | Reference |
+|----------|----------|
+| complete, compgen, compopt, COMPREPLY, COMP_WORDS, COMP_CWORD, COMP_LINE, COMP_POINT, COMP_TYPE, COMP_WORDBREAKS, compspec, completion function, _init_completion, _comp_initialize, _completion_loader, dynamic loading, exit status 124, bash-completion helpers, _filedir, _comp_compgen, _comp_split, _comp_quote, _comp_dequote, _comp_reassemble, _comp_xfunc, completion registration, completion options, nospace, filenames, noquote, nosort, plusdirs, bashdefault, default, dirnames, fullquote, menu-complete | [references/completion.md](references/completion.md) |
+| Readline, .inputrc, bind, key binding, editing mode, emacs, vi, completion variables, mark-directories, show-all-if-ambiguous, colored-stats, visible-stats, completion-prefix-display-length, colored-completion-prefix, bell-style, completion-display-width, page-completions, completion-query-items, menu-complete-display-prefix, skip-completed-text, macro, kill-ring, yank, bracketed-paste, READLINE_LINE, READLINE_POINT, READLINE_MARK, READLINE_ARGUMENT | [references/readline.md](references/readline.md) |
+| quoting, single quotes, double quotes, ANSI-C quoting, $'...', escape character, backslash, word splitting, IFS, pathname expansion, globbing, brace expansion, tilde expansion, parameter expansion, command substitution, arithmetic expansion, process substitution, COMP_WORDBREAKS quoting, dequoting, _comp_dequote, _comp_quote, FIGNORE, nullglob, dotglob | [references/quoting-expansion.md](references/quoting-expansion.md) |
+| execution, subshell, fork, exec, process group, pipeline, job control, signal, trap, DEBUG trap, EXIT trap, ERR trap, RETURN trap, PROMPT_COMMAND, PS0, PS1, PS2, PS3, PS4, prompt escape, foreground, background, SIGINT, SIGHUP, SIGTTIN, SIGTTOU, disown, huponexit, lastpipe, pipefail, command_not_found_handle | [references/execution.md](references/execution.md) |
+| startup, .bashrc, .bash_profile, .profile, /etc/profile, login shell, interactive shell, non-interactive, BASH_ENV, ENV, --login, --norc, --noprofile, sh invocation, POSIX mode, remote shell, SSH, elevated privileges, shell options, shopt, set | [references/startup.md](references/startup.md) |
+
+## Quick Guide
+
+- **How do I write a completion function?** → [references/completion.md](references/completion.md)
+- **How does Readline handle completion display?** → [references/readline.md](references/readline.md)
+- **How does quoting affect completions?** → [references/quoting-expansion.md](references/quoting-expansion.md)
+- **How does bash execute commands and handle signals?** → [references/execution.md](references/execution.md)
+- **Which startup files does bash read?** → [references/startup.md](references/startup.md)
+- **What are the COMP_* variables?** → [references/completion.md](references/completion.md)
+- **How does the bash-completion project work?** → [references/completion.md](references/completion.md)
+- **How do I configure .inputrc for completion?** → [references/readline.md](references/readline.md)
+- **How does COMP_WORDBREAKS break words?** → [references/completion.md](references/completion.md) and [references/quoting-expansion.md](references/quoting-expansion.md)
+- **How do I control nospace/filenames/noquote?** → [references/completion.md](references/completion.md)
+- **How do traps and PROMPT_COMMAND work?** → [references/execution.md](references/execution.md)
+- **How do I debug completion functions?** → [references/completion.md](references/completion.md)
+
+## Cross-Project References
+
+For carapace-specific bash integration (snippet, patch phase, value formatting), see the **carapace-dev** skill → `references/shell-bash.md`.

--- a/skills/bash/references/completion.md
+++ b/skills/bash/references/completion.md
@@ -1,0 +1,554 @@
+# Bash Programmable Completion
+
+In-depth reference for bash's programmable completion system — the builtins, variables, registration, and the bash-completion project's helper framework.
+
+## The Completion Flow
+
+When the user presses TAB (or another completion key), bash:
+
+1. Identifies the command word and searches for a matching compspec (completion specification)
+2. Sets `COMP_*` variables in the completion function's environment
+3. Invokes the registered function or command
+4. Reads `COMPREPLY` for completion candidates
+5. Passes candidates to Readline for display
+
+### Compspec Search Order
+
+Bash searches for a compspec in this order:
+
+1. **Full pathname** — if the command contains a `/`, the full path is checked first
+2. **Portion after final slash** — e.g., `/usr/bin/git` → check for `git`
+3. **Default compspec** (`-D`) — for commands with no compspec
+4. **Alias expansion result** — if the command is an alias, check the expansion
+
+### Match Generation Order
+
+Within a compspec, matches are generated in this order:
+
+1. Actions from `-A` options (e.g., `-A file`, `-A command`)
+2. Filename patterns from `-G globpat`
+3. Words from `-W wordlist` (split by IFS, then expanded)
+4. Shell function via `-F function` (populates `COMPREPLY`)
+5. External command via `-C command` (stdout becomes completions)
+
+After generation:
+
+6. `-X filterpat` removes matching completions (or non-matching if `!` prefix)
+7. `-P prefix` and `-S suffix` are applied
+8. Fallback options are tried if no matches: `-o dirnames`, `-o plusdirs`, `-o bashdefault`, `-o default`
+
+## COMP_* Variables
+
+When a completion function is invoked, bash sets these variables:
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `COMP_WORDS` | Array | All words on the command line (split by whitespace) |
+| `COMP_CWORD` | Integer | Index in `COMP_WORDS` of the word containing the cursor |
+| `COMP_LINE` | String | The entire command line as a single string |
+| `COMP_POINT` | Integer | Cursor position within `COMP_LINE` (0-based index) |
+| `COMP_TYPE` | Integer | Type of completion attempt (see table below) |
+| `COMP_KEY` | Integer | Key pressed to invoke completion (decimal ASCII) |
+| `COMP_WORDBREAKS` | String | Characters that Readline treats as word breaks |
+
+### COMP_TYPE Values
+
+| Value | Character | Meaning |
+|-------|-----------|---------|
+| `9` | TAB | Normal completion (first TAB press) |
+| `33` | `!` | Listing alternatives on partial word |
+| `37` | `%` | Menu completion |
+| `63` | `?` | Listing after successive TABs |
+| `64` | `@` | Listing if word not unmodified |
+
+### COMP_WORDBREAKS
+
+Default value: `" \t\n\"'@><=;|&(:`". These characters split the "word being completed" — bash only passes the **last segment** (after the most recent word-break character) as `$2` to the completion function.
+
+This has major implications:
+
+- **Colon (`:`)** — breaks `origin/main`, `user@host:port`, `File::Basename`
+- **Equals (`=`)** — breaks `--option=value` into `--option` and `value`
+- **At sign (`@`)** — breaks `user@host`
+
+Completion functions must reassemble the full word by re-parsing `COMP_LINE` or using helpers like `_comp__reassemble_words`.
+
+## The `complete` Builtin
+
+```bash
+complete [-abcdefgjksuv] [-o comp-option] [-DEI] [-A action]
+         [-G globpat] [-W wordlist] [-F function] [-C command]
+         [-X filterpat] [-P prefix] [-S suffix] name [name ...]
+complete -pr [-DEI] [name ...]
+```
+
+### Action Options (`-A action` / short flags)
+
+| Action | Short | Description |
+|--------|-------|-------------|
+| `alias` | `-a` | Alias names |
+| `arrayvar` | | Array variable names |
+| `binding` | | Readline key binding names |
+| `builtin` | `-b` | Shell builtin commands |
+| `command` | `-c` | Command names from PATH |
+| `directory` | `-d` | Directory names |
+| `disabled` | | Disabled shell builtins |
+| `enabled` | | Enabled shell builtins |
+| `export` | `-e` | Exported shell variables |
+| `file` | `-f` | File and directory names |
+| `function` | | Shell function names |
+| `group` | `-g` | Group names |
+| `helptopic` | | Help topics (`help` builtin) |
+| `hostname` | | Hostnames from `HOSTFILE` |
+| `job` | `-j` | Job names (if job control active) |
+| `keyword` | `-k` | Shell reserved words |
+| `running` | | Running jobs |
+| `service` | `-s` | Service names |
+| `setopt` | | Valid `set -o` arguments |
+| `shopt` | | `shopt` option names |
+| `signal` | | Signal names |
+| `stopped` | | Stopped jobs |
+| `user` | `-u` | User names |
+| `variable` | `-v` | All shell variables |
+
+### Completion Options (`-o comp-option`)
+
+| Option | Description |
+|--------|-------------|
+| `bashdefault` | Fall back to Bash default completions if compspec generates no matches |
+| `default` | Use Readline's default filename completion if no matches |
+| `dirnames` | Attempt directory name completion if no matches |
+| `filenames` | Tell Readline completions are filenames (add slash to dirs, quote special chars, suppress trailing spaces) |
+| `fullquote` | Quote all completed words (not just filenames) |
+| `noquote` | Don't quote completed words |
+| `nosort` | Don't sort completions alphabetically (Bash 4.4+) |
+| `nospace` | Don't append space after completion |
+| `plusdirs` | After generating matches, also add directory completions |
+
+### Special Registration Options
+
+| Option | Description |
+|--------|-------------|
+| `-D` | Apply to "default" command completion (commands with no compspec) |
+| `-E` | Apply to "empty" command completion (blank line) |
+| `-I` | Apply to initial word (command name completion) |
+| `-p` | Print existing compspecs (for reuse) |
+| `-r` | Remove compspec for specified names |
+
+Priority: `-D` > `-E` > `-I`. If any of these are supplied, name arguments are ignored.
+
+### Other Options
+
+| Option | Description |
+|--------|-------------|
+| `-C command` | Execute command in subshell; stdout becomes completions |
+| `-F function` | Execute shell function; read `COMPREPLY` for results |
+| `-G globpat` | Expand filename pattern for completions |
+| `-W wordlist` | Split wordlist by IFS, expand each word, match against current word |
+| `-X filterpat` | Remove completions matching pattern; `!` negates |
+| `-P prefix` | Prepend prefix to each completion |
+| `-S suffix` | Append suffix to each completion |
+
+### `-F function` Details
+
+When the function is called:
+
+- `$1` — name of the command whose arguments are being completed
+- `$2` — word being completed
+- `$3` — word preceding the word being completed
+
+The function populates `COMPREPLY`. When it finishes, bash reads `COMPREPLY` for candidates.
+
+**Exit status 124**: If the function returns 124, bash restarts the completion from the beginning. This enables dynamic loading — the function can source a completion file and return 124 to re-trigger with the newly registered compspec.
+
+## The `compgen` Builtin
+
+```bash
+compgen [-V varname] [option] [word]
+```
+
+Generates completion matches and writes them to stdout (or stores in `varname` with `-V`). Accepts the same options as `complete` except `-p`, `-r`, `-D`, `-E`, `-I`.
+
+### Common Usage
+
+```bash
+compgen -W "start stop status" -- "$cur"     # Word list
+compgen -f -- "$cur"                          # Filenames
+compgen -d -- "$cur"                          # Directories
+compgen -A command -- "$cur"                  # Commands
+compgen -A variable -- "$cur"                # Variables
+compgen -A function -- "$cur"                # Functions
+compgen -A user -- "$cur"                    # Users
+compgen -A hostname -- "$cur"                # Hostnames
+compgen -W "prod dev" -P "--env=" -- "$cur"  # With prefix
+compgen -f -X '!*.txt' -- "$cur"            # Only .txt files
+```
+
+The `--` separates options from the word argument. Always use `--` to prevent the word from being interpreted as an option.
+
+## The `compopt` Builtin
+
+```bash
+compopt [-o option] [+o option] [-DEI] [name]
+```
+
+Modifies completion options dynamically — either for a named command or for the currently-executing completion (if no name given).
+
+- `-o option` — enable option
+- `+o option` — disable option
+- `-D` / `-E` / `-I` — apply to default/empty/initial completion
+
+This is the primary way to control nospace, filenames, nosort, etc. from within a completion function:
+
+```bash
+_mycomp() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    COMPREPLY=($(compgen -f -- "$cur"))
+    compopt -o filenames   # Tell Readline these are filenames
+    compopt -o nospace      # Don't append trailing space
+}
+```
+
+## Writing Completion Functions
+
+### Basic Pattern
+
+```bash
+_mytool_completion() {
+    local cur prev words cword
+    _init_completion -n = || return
+
+    # Handle option arguments
+    case "$prev" in
+        --mode|-m)
+            COMPREPLY=($(compgen -W "verbose quiet debug" -- "$cur"))
+            return
+            ;;
+        --output|-o)
+            COMPREPLY=($(compgen -d -- "$cur"))
+            compopt -o filenames
+            return
+            ;;
+    esac
+
+    # Handle options
+    case "$cur" in
+        -*)
+            COMPREPLY=($(compgen -W "--help --version --mode --output" -- "$cur"))
+            ;;
+    esac
+}
+complete -F _mytool_completion mytool
+```
+
+### Without `_init_completion`
+
+```bash
+_mycomp() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+    # ... logic ...
+    COMPREPLY=($(compgen -W "opt1 opt2" -- "$cur"))
+}
+complete -F _mycomp mycmd
+```
+
+### Handling Subcommands
+
+```bash
+_mytool() {
+    local cur prev words cword
+    _init_completion || return
+
+    local subcmd="${words[1]}"
+
+    # If no subcommand yet, complete subcommand names
+    if [[ $cword -eq 1 ]]; then
+        COMPREPLY=($(compgen -W "build deploy status" -- "$cur"))
+        return
+    fi
+
+    # Dispatch to subcommand handlers
+    case "$subcmd" in
+        build)  _mytool_build ;;
+        deploy) _mytool_deploy ;;
+        status) _mytool_status ;;
+    esac
+}
+```
+
+### Handling `--` Delimiter
+
+After `--`, all arguments are positional (not options):
+
+```bash
+_mytool() {
+    local cur prev words cword
+    _init_completion || return
+
+    # Check if -- has been seen
+    local i=1
+    for ((i=1; i<cword; i++)); do
+        if [[ "${words[i]}" == "--" ]]; then
+            # After --, only positional args
+            COMPREPLY=($(compgen -f -- "$cur"))
+            compopt -o filenames
+            return
+        fi
+    done
+
+    # Normal option/argument handling
+    # ...
+}
+```
+
+### Dynamic Option Parsing
+
+Parse `--help` output to generate option completions:
+
+```bash
+# Using bash-completion helpers
+_parse_help "$1" --help       # Parse --help output for options
+_parse_usage "$1" --help      # Parse usage strings
+
+# Manual approach
+COMPREPLY=($(compgen -W "$($1 --help 2>&1 | \
+    sed -ne 's/.*\(--[a-z][a-z-]*\).*/\1/p' | sort -u)" -- "$cur"))
+```
+
+## The bash-completion Project
+
+The [bash-completion](https://github.com/scop/bash-completion) project provides a framework of helper functions and hundreds of pre-built completions.
+
+### Directory Structure
+
+```
+/usr/share/bash-completion/
+├── bash_completion              # Main script with helper functions
+└── completions/                 # Individual command completions
+    ├── git
+    ├── ssh
+    ├── tar
+    └── ...
+
+~/.local/share/bash-completion/
+└── completions/                 # User-specific completions
+
+/etc/bash_completion.d/         # Legacy compat directory
+```
+
+### Search Order for Completion Files
+
+1. `BASH_COMPLETION_USER_DIR/completions/` (user)
+2. Main `bash_completion` directory `completions/` (system)
+3. Command's installation prefix `share/bash-completion/completions/`
+4. `XDG_DATA_DIRS` `bash-completion/completions/`
+
+### Dynamic Loading (`_completion_loader`)
+
+Completions are loaded on demand, not at shell startup:
+
+```bash
+_completion_loader() {
+    . "/usr/share/bash-completion/completions/$1" >/dev/null 2>&1 && return 124
+}
+complete -D -F _completion_loader -o bashdefault -o default
+```
+
+The `-D` flag registers this as the default handler. When a command with no compspec is completed:
+
+1. `_completion_loader` sources the matching file
+2. Returns 124 → bash restarts completion with the newly registered compspec
+3. The actual completion function runs
+
+### Naming Conventions
+
+| Pattern | Purpose |
+|---------|---------|
+| `_comp_cmd_COMMAND` | Main completion function for a command |
+| `_comp_cmd_COMMAND__HELPER` | Command-specific helper |
+| `_comp_xfunc_COMMAND_ACTION` | Cross-functional helper (usable by other commands) |
+| `_comp_compgen_*` | Completion generator functions |
+| `_comp_*` | Core helper functions |
+
+### Core Helper Functions
+
+| Function | Purpose |
+|----------|---------|
+| `_comp_initialize` | Initialize `cur`, `prev`, `words`, `cword` (replaces `_init_completion`) |
+| `_init_completion` | Legacy wrapper around `_comp_initialize` |
+| `_comp_compgen` | Primary completion generator (calls compgen or generator functions) |
+| `_comp_compgen_split` | Split text and generate completions (safer than `compgen -W "$(cmd)"`) |
+| `_comp_compgen_set` | Directly set completion array with words |
+| `_comp_split` | Split string into array (safe IFS handling) |
+| `_comp_quote` | Shell-quote argument (result in `REPLY`) |
+| `_comp_dequote` | Safely expand quoted word (result in `REPLY`) |
+| `_comp__reassemble_words` | Reassemble words excluding chars from COMP_WORDBREAKS |
+| `_comp_expand_glob` | Expand glob pattern in controlled environment |
+| `_comp_looks_like_path` | Check if argument looks like a path (`/`, `.`, `~`) |
+| `_comp_have_command` | Check if command exists in PATH |
+| `_comp_userland` | Detect OS userland (GNU, BSD) |
+| `_filedir` | File completion (handles spaces in filenames) |
+| `_parse_help` | Parse `--help` output for options |
+| `_parse_usage` | Parse usage strings for options |
+| `_comp_count_args` | Count arguments (respects `--` delimiter) |
+| `_comp_upvars` | Assign variables one scope above caller |
+
+### `_comp_compgen` Options
+
+| Option | Description |
+|--------|-------------|
+| `-a` | Append to COMPREPLY instead of replacing |
+| `-v arr` | Store results in array `arr` instead of COMPREPLY |
+| `-c cur` | Use `cur` as prefix filter |
+| `-R` | Raw output without filtering |
+| `-C dir` | Evaluate in specified directory |
+| `-P prefix` | Prepend prefix to completions |
+| `-F sep` | Set separator for word splitting |
+| `-x cmd` | Call exported generator `_comp_xfunc_CMD_compgen_NAME` |
+| `-i cmd` | Call internal generator `_comp_cmd_CMD__compgen_NAME` |
+
+### Legacy to Modern Function Migration
+
+| Deprecated | Modern |
+|------------|--------|
+| `_init_completion` | `_comp_initialize` |
+| `_filedir` | `_comp_compgen -a filedir` |
+| `_get_cword` | `_comp_get_words cur` |
+| `_count_args` | `_comp_count_args` |
+| `have` | `_comp_have_command` |
+
+## Controlling the Completion Menu
+
+### Menu Completion (Cycle Through Matches)
+
+By default, TAB shows all matches or inserts the common prefix. To cycle through matches one at a time:
+
+```bash
+# In .inputrc
+TAB: menu-complete
+"\e[Z": menu-complete-backward   # Shift-Tab
+
+# Or via bind
+bind 'TAB:menu-complete'
+bind '"\e[Z": menu-complete-backward'
+```
+
+### Readline Variables Affecting Completion Display
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `show-all-if-ambiguous` | `off` | Show all matches on first TAB (instead of bell) |
+| `show-all-if-unmodified` | `off` | Show all matches if no unique prefix remains |
+| `completion-query-items` | `100` | Prompt before showing more than N completions |
+| `completion-display-width` | `-1` | Screen columns for match display; `0` = one per line |
+| `page-completions` | `on` | Use internal pager for long completion lists |
+| `print-completions-horizontally` | `off` | Sort horizontally instead of vertically |
+| `colored-stats` | `off` | Use LS_COLORS to indicate file types |
+| `visible-stats` | `off` | Append file-type indicator character |
+| `colored-completion-prefix` | `off` | Color the common prefix differently |
+| `completion-prefix-display-length` | `0` | Ellipsize common prefix longer than N |
+| `menu-complete-display-prefix` | `off` | Show common prefix before cycling |
+| `skip-completed-text` | `off` | Don't duplicate text after cursor on mid-word completion |
+| `mark-directories` | `on` | Append `/` to directory completions |
+| `mark-symlinked-directories` | `off` | Append `/` to symlinks pointing to directories |
+| `match-hidden-files` | `on` | Include dotfiles in completion |
+| `completion-ignore-case` | `off` | Case-insensitive matching |
+| `completion-map-case` | `off` | Treat `-` and `_` as equivalent (with `completion-ignore-case`) |
+| `expand-tilde` | `off` | Perform tilde expansion during completion |
+| `disable-completion` | `off` | Disable completion entirely |
+
+See [references/readline.md](references/readline.md) for full Readline variable reference.
+
+## Debugging Completion Functions
+
+### Trace Execution
+
+```bash
+_mycomp() {
+    set -x  # Enable tracing
+    # ... completion logic ...
+    set +x  # Disable tracing
+}
+```
+
+### Log to File
+
+```bash
+_mycomp() {
+    echo "COMP_WORDS: ${COMP_WORDS[@]}" >> ~/comp-debug.log
+    echo "COMP_CWORD: $COMP_CWORD" >> ~/comp-debug.log
+    echo "cur: $cur" >> ~/comp-debug.log
+    # ...
+}
+```
+
+### Test with compgen
+
+```bash
+# Source the completion
+source /usr/share/bash-completion/completions/mytool
+
+# Test compgen directly
+compgen -W "start stop restart" -- "re"
+# Output: restart
+
+# Simulate completion function
+_mytool_completion; echo "${COMPREPLY[@]}"
+```
+
+### Inspect Registered Completions
+
+```bash
+# Print all compspecs
+complete -p
+
+# Print compspec for specific command
+complete -p mytool
+
+# Print compopt settings
+compopt mytool
+```
+
+## Installing Completions
+
+### User-Specific
+
+```bash
+~/.local/share/bash-completion/completions/mytool
+```
+
+### System-Wide
+
+```bash
+/usr/share/bash-completion/completions/mytool
+```
+
+### Legacy
+
+```bash
+/etc/bash_completion.d/mytool
+```
+
+### In .bashrc
+
+```bash
+# For completions not in standard directories
+source /path/to/mytool-completion.bash
+```
+
+## References
+
+- [GNU Bash Manual: Programmable Completion](https://www.gnu.org/software/bash/manual/html_node/Programmable-Completion.html)
+- [GNU Bash Manual: Programmable Completion Builtins](https://www.gnu.org/software/bash/manual/html_node/Programmable-Completion-Builtins.html)
+- [GNU Bash Manual: A Programmable Completion Example](https://www.gnu.org/software/bash/manual/html_node/A-Programmable-Completion-Example.html)
+- [bash-completion GitHub Repository](https://github.com/scop/bash-completion)
+- [bash-completion Architecture (DeepWiki)](https://deepwiki.com/scop/bash-completion/3.1-completion-architecture)
+- [bash-completion Helper Functions (DeepWiki)](https://deepwiki.com/scop/bash-completion/2.2-helper-functions)
+
+## Related Skills
+
+- **references/readline.md** — Readline variables and key bindings that control completion display
+- **references/quoting-expansion.md** — How quoting and COMP_WORDBREAKS affect completion
+- **references/execution.md** — How completion functions execute (subshell vs current shell)
+- **references/startup.md** — Where to install completions and when they're loaded

--- a/skills/bash/references/execution.md
+++ b/skills/bash/references/execution.md
@@ -1,0 +1,335 @@
+# Bash Execution Model
+
+In-depth reference for how bash executes commands, manages processes, handles signals and traps, and interacts with the terminal.
+
+## Command Search and Execution
+
+Bash searches for commands in this order:
+
+1. **Shell functions** — executed in current shell context
+2. **Shell builtins** — invoked as builtin within the shell process
+3. **PATH lookup** — searches `$PATH` directories, uses hash table for caching
+4. **`command_not_found_handle`** — if defined, executed in subshell
+5. **External commands** — fork/exec in separate process
+
+If the command name contains a `/`, bash executes it directly as a program (no PATH search).
+
+## Simple Command Expansion Order
+
+When executing a simple command, bash performs:
+
+1. **Variable assignments and redirections** — saved for later processing
+2. **Word expansion** — tilde, parameter, command substitution, arithmetic, quote removal
+3. **Redirections** — performed
+4. **Variable assignment values** — undergo tilde, parameter, command substitution, arithmetic, quote removal
+
+If no command name remains after expansion, variable assignments affect the current shell. Otherwise, they only affect the executed command's environment.
+
+## Execution Environments
+
+### Current Shell Environment
+
+Contains:
+- Open files inherited at invocation (modified by `exec` redirections)
+- Current working directory
+- File creation mode mask (`umask`)
+- Current traps
+- Shell parameters (set by assignment, `set`, or inherited)
+- Shell functions (defined or inherited)
+- Shell options (enabled at invocation or by `set`/`shopt`)
+- Shell aliases
+- Process IDs (background jobs, `$$`, `$PPID`)
+
+### Subshell Environment (for External Commands)
+
+Contains:
+- Open files (plus redirections)
+- Current working directory
+- File creation mode mask
+- Exported variables and functions
+- Traps reset to inherited values from parent
+
+**Key distinction**: Changes in a subshell cannot affect the parent's environment.
+
+### What Creates a Subshell
+
+| Construct | Subshell? |
+|-----------|-----------|
+| Command substitution `$(cmd)` | Yes |
+| Grouped commands `(cmd)` | Yes |
+| Pipeline elements (except last with `lastpipe`) | Yes |
+| Background commands `cmd &` | Yes |
+| Process substitution `<(cmd)` | Yes |
+| Shell functions | **No** — current shell |
+| `source`/`.` script | **No** — current shell |
+| `exec cmd` | **No** — replaces current process |
+
+## External Commands vs Builtins vs Functions
+
+### External Commands
+
+- Executed in separate process (fork/exec)
+- Inherit signal handlers from shell (unless set to ignore)
+- Cannot affect shell's execution environment
+- `$_` set to full pathname and passed in environment
+
+### Shell Functions
+
+- **Executed in current shell context** — no new process
+- Arguments become positional parameters (`$1`, `$2`, etc.)
+- `$0` unchanged; `FUNCNAME[0]` set to function name
+- Use `local` for local variables
+- Dynamic scoping (variables visible to called functions)
+- `DEBUG` and `RETURN` traps **not inherited** by default (need `trace` attribute or `-o functrace`)
+- `ERR` trap **not inherited** by default (need `-o errtrace`)
+- `return` exits function and resumes after call site
+
+### Shell Builtins
+
+- Part of the shell itself
+- Execute within the shell process
+- In POSIX mode, special builtins affect the shell environment
+- Some builtins in pipelines execute in subshell (unless `lastpipe`)
+
+## Pipelines
+
+```bash
+[time [-p]] [!] command1 [ | command2 ] ...
+```
+
+- Output of each command connected via pipe to input of next
+- Each command executed in its **own subshell** (separate process)
+- `|&` connects stderr to stdout through pipe
+- Exit status: last command's (or last non-zero with `pipefail`)
+- With `!`, exit status is logical negation
+- With `lastpipe` option (and no job control), last element runs in current shell
+
+```bash
+# Enable lastpipe for performance
+shopt -s lastpipe
+echo "hello" | read var   # var is set in current shell
+```
+
+## Job Control
+
+### Process Groups
+
+- Each process has a **process group ID** (PGID)
+- **Foreground process group** — PGID equals terminal's PGID; receives keyboard signals
+- **Background process groups** — different PGID; immune to keyboard signals
+- Background processes attempting terminal I/O receive `SIGTTIN`/`SIGTTOU`
+
+### Job Control Features
+
+| Feature | Description |
+|---------|-------------|
+| `^Z` (suspend) | Stops current foreground process, returns to shell |
+| `^Y` (delayed suspend) | Stops on next read attempt |
+| `bg %n` | Resume job in background |
+| `fg %n` | Bring job to foreground |
+| `jobs` | List jobs |
+| `disown %n` | Remove from jobs table (avoid SIGHUP) |
+| `wait %n` | Wait for job to complete |
+
+### Job Specifiers
+
+| Specifier | Meaning |
+|-----------|---------|
+| `%n` | Job number n |
+| `%%` or `%+` | Current job |
+| `%-` | Previous job |
+| `%string` | Job whose command starts with `string` |
+| `%?string` | Job whose command contains `string` |
+
+### Job Control Disabled (Non-Interactive)
+
+- Shell and foreground command are in same process group
+- `^C` sends `SIGINT` to all processes in that group
+- Shell waits for command, then decides action based on whether command handled the signal
+
+## Signals
+
+### Default Signal Handling in Interactive Bash
+
+| Signal | Default Action |
+|--------|---------------|
+| `SIGTERM` | Ignored |
+| `SIGQUIT` | Ignored |
+| `SIGINT` | Caught (interruptible `wait`) |
+| `SIGTTIN` | Ignored (with job control) |
+| `SIGTTOU` | Ignored (with job control) |
+| `SIGTSTP` | Ignored (with job control) |
+
+### SIGHUP Handling
+
+- Shell exits by default on `SIGHUP`
+- Before exit, interactive shell resends `SIGHUP` to all jobs
+- Sends `SIGCONT` to stopped jobs
+- `disown` removes from jobs table or marks to avoid `SIGHUP`
+- `huponexit` option sends `SIGHUP` to all jobs on interactive login shell exit
+
+### Signal Inheritance for Child Processes
+
+- Non-builtin commands inherit signal handlers from shell (unless set to ignore)
+- Async commands (without job control) ignore `SIGINT` and `SIGQUIT`
+- Command substitutions ignore `SIGTTIN`, `SIGTTOU`, `SIGTSTP`
+
+## Traps
+
+```bash
+trap [-lpP] [action] [sigspec ...]
+```
+
+### Trap Types
+
+| Signal | When Triggered |
+|--------|---------------|
+| `DEBUG` | Before every simple command, `for`/`case`/`select`/`((`/`[[`, and first command in function |
+| `EXIT` (0) | When shell exits (any reason) |
+| `ERR` | When command returns non-zero (subject to conditions) |
+| `RETURN` | When shell function or sourced script finishes |
+
+### ERR Trap Conditions
+
+`ERR` is **not** executed when:
+
+- Command after `while`/`until` or `if`/`elif`
+- Command after final `&&`/`||`
+- All but last command in pipeline (unless `pipefail`)
+- Return status inverted with `!`
+
+### Trap Inheritance
+
+| Trap | Inherited by Functions? | Inherited by Subshells? |
+|------|------------------------|------------------------|
+| `DEBUG` | Only with `declare -t` or `-o functrace` | Reset to parent's inherited values |
+| `RETURN` | Only with `declare -t` or `-o functrace` | Reset to parent's inherited values |
+| `ERR` | Only with `-o errtrace` | Reset to parent's inherited values |
+| Signal traps | No (unless `trace` attribute) | Reset to parent's inherited values |
+
+### Trap Timing
+
+- When waiting for a foreground command: trap executes after command finishes
+- When waiting via `wait` for async command: trap executes immediately after `wait` returns
+
+### Debug Trap and Completion
+
+The `DEBUG` trap fires before every simple command. This can interfere with completion functions if they trigger commands. Completion functions run in the current shell, so `DEBUG` traps are active during their execution.
+
+## PROMPT_COMMAND
+
+```bash
+# Single command
+PROMPT_COMMAND="history -a"
+
+# Array (each element executed in order)
+PROMPT_COMMAND=("history -a" "history -c" "history -r")
+```
+
+- Executed in current shell environment before displaying `PS1`
+- If set as array, each element is executed sequentially
+- If set as string, value is executed as a command
+- Useful for: updating window title, syncing history, setting dynamic variables
+
+## Prompt Variables
+
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `PS0` | Displayed after reading command, before execution | |
+| `PS1` | Primary prompt | `\s-\v\$` |
+| `PS2` | Continuation prompt | `> ` |
+| `PS3` | Prompt for `select` command | `#? ` |
+| `PS4` | Trace prompt (with `set -x`) | `+ ` |
+
+### PS1 Escape Sequences
+
+| Sequence | Meaning |
+|----------|---------|
+| `\a` | Bell |
+| `\d` | Date ("weekday month date") |
+| `\D{format}` | `strftime` format |
+| `\e` | Escape character |
+| `\h` | Hostname (short) |
+| `\H` | Hostname (full) |
+| `\j` | Number of jobs |
+| `\l` | Terminal device name |
+| `\n` | Newline |
+| `\r` | Carriage return |
+| `\s` | Shell name |
+| `\t` | Time (24-hour HH:MM:SS) |
+| `\T` | Time (12-hour HH:MM:SS) |
+| `\@` | Time (12-hour am/pm) |
+| `\A` | Time (24-hour HH:MM) |
+| `\u` | Username |
+| `\v` | Bash version (short) |
+| `\V` | Bash version (full) |
+| `\w` | Working directory (with `~` abbreviation) |
+| `\W` | Basename of working directory |
+| `\!` | History number |
+| `\#` | Command number |
+| `\$` | `#` if UID=0, else `$` |
+| `\nnn` | Octal character |
+| `\\` | Backslash |
+| `\[` | Begin non-printing sequence (for terminal escapes) |
+| `\]` | End non-printing sequence |
+
+### Prompt Expansion
+
+After decoding escape sequences, prompt strings undergo: parameter expansion, command substitution, arithmetic expansion, and quote removal (subject to `promptvars` option).
+
+### Common PS1 Patterns
+
+```bash
+# User@host:directory$
+PS1='\u@\h:\w\$ '
+
+# With git branch (via PROMPT_COMMAND)
+PS1='\u@\h:\w$(__git_ps1)\$ '
+
+# Colored prompt
+PS1='\[\e[1;32m\]\u@\h\[\e[0m\]:\[\e[1;34m\]\w\[\e[0m\]\$ '
+
+# With exit code indicator
+PS1='$? \u@\h:\w\$ '
+```
+
+## Terminal Interaction
+
+### Foreground/Background Process Groups
+
+- **Foreground**: PGID equals terminal's PGID; receives keyboard signals (`SIGINT`, `SIGTSTP`)
+- **Background**: Different PGID; immune to keyboard signals
+- Background processes attempting terminal read receive `SIGTTIN`
+- Background processes attempting terminal write receive `SIGTTOU` (if `stty tostop`)
+
+### How Bash Arranges Process Groups
+
+1. Shell creates a new process group for each pipeline
+2. Sets the pipeline's PGID using `setpgid()`
+3. Places the pipeline in the foreground with `tcsetpgrp()` (if not background)
+4. The terminal driver delivers keyboard signals to the foreground group
+
+### Bracketed Paste
+
+Bash 5.1+ supports bracketed paste mode (enabled by default in Readline):
+
+- Terminal wraps pasted text in `\e[200~` ... `\e[201~` sequences
+- Readline treats the entire paste as a single unit
+- Prevents accidental execution of pasted commands
+- Controlled by `enable-bracketed-paste` Readline variable
+
+## References
+
+- [GNU Bash Manual: Executing Commands](https://www.gnu.org/software/bash/manual/html_node/Executing-Commands.html)
+- [GNU Bash Manual: Command Search and Execution](https://www.gnu.org/software/bash/manual/html_node/Command-Search-and-Execution.html)
+- [GNU Bash Manual: Command Execution Environment](https://www.gnu.org/software/bash/manual/html_node/Command-Execution-Environment.html)
+- [GNU Bash Manual: Signals](https://www.gnu.org/software/bash/manual/html_node/Signals.html)
+- [GNU Bash Manual: Job Control](https://www.gnu.org/software/bash/manual/html_node/Job-Control.html)
+- [GNU Bash Manual: Pipelines](https://www.gnu.org/software/bash/manual/html_node/Pipelines.html)
+- [GNU Bash Manual: Controlling the Prompt](https://www.gnu.org/software/bash/manual/html_node/Controlling-the-Prompt.html)
+- [GNU Bash Manual: Bourne Shell Builtins (trap)](https://www.gnu.org/software/bash/manual/html_node/Bourne-Shell-Builtins.html)
+
+## Related Skills
+
+- **references/completion.md** — how completion functions execute (current shell vs subshell)
+- **references/startup.md** — when traps and PROMPT_COMMAND are set up

--- a/skills/bash/references/quoting-expansion.md
+++ b/skills/bash/references/quoting-expansion.md
@@ -1,0 +1,420 @@
+# Bash Quoting and Expansion
+
+In-depth reference for bash's quoting rules, expansion order, word splitting, and how they affect completion.
+
+## Quoting Mechanisms
+
+### 1. Escape Character (`\`)
+
+A non-quoted backslash preserves the literal value of the next character, with the exception of newline. A `\newline` pair is treated as line continuation (the pair is removed from the input).
+
+### 2. Single Quotes (`'...'`)
+
+Preserves the literal value of **every** character. No escape is possible — a single quote cannot appear between single quotes, even when preceded by backslash.
+
+```bash
+echo 'hello world'       # hello world
+echo 'it'\''s'           # it's (end quote, escaped quote, reopen quote)
+echo '$HOME \n \t'       # $HOME \n \t  (all literal)
+```
+
+### 3. Double Quotes (`"..."`)
+
+Preserves literal value of all characters except: `$`, `` ` ``, `\`, and `!` (when history expansion enabled; in POSIX mode, `!` has no special meaning).
+
+**Backslash in double quotes** — retains special meaning only when followed by: `$`, `` ` ``, `"`, `\`, or `newline`. These pairs are **removed**. Backslashes before other characters are left as-is.
+
+```bash
+echo "$HOME"             # /home/user  (parameter expansion)
+echo "hello\nworld"      # hello\nworld  (\n is literal)
+echo "say \"hello\""     # say "hello"  (\" is removed)
+echo "cost: \$5"         # cost: $5  (\$ is removed)
+```
+
+### 4. ANSI-C Quoting (`$'...'`)
+
+Expands backslash escape sequences per ANSI C standard. The result is treated as single-quoted.
+
+| Sequence | Meaning |
+|----------|---------|
+| `\a` | Alert (bell) |
+| `\b` | Backspace |
+| `\e` / `\E` | Escape character (not in ANSI C) |
+| `\f` | Form feed |
+| `\n` | Newline |
+| `\r` | Carriage return |
+| `\t` | Horizontal tab |
+| `\v` | Vertical tab |
+| `\\` | Backslash |
+| `\'` | Single quote |
+| `\"` | Double quote |
+| `\?` | Question mark |
+| `\nnn` | Octal character (1-3 digits) |
+| `\xHH` | Hex character (1-2 digits) |
+| `\uHHHH` | Unicode character (1-4 hex digits) |
+| `\UHHHHHHHH` | Unicode character (1-8 hex digits) |
+| `\cx` | Control-x character |
+
+```bash
+echo $'hello\nworld'     # Two lines
+echo $'\x41'             # A
+echo $'\t'               # Tab character
+echo $'it\'s'            # it's
+```
+
+### 5. Locale Translation (`$"..."`)
+
+Prefixing a double-quoted string with `$` causes translation via `gettext`. If locale is `C`/`POSIX` or no translation exists, the `$` is ignored and the string is treated as double-quoted.
+
+## Expansion Order
+
+Bash performs expansions in this specific order:
+
+1. **Brace expansion** — `a{d,c,b}e` → `ade ace abe`
+2. **Tilde expansion** — `~` → `$HOME`
+3. **Parameter and variable expansion** — `$var`, `${var}`, `${var:-default}`
+4. **Command substitution** — `$(cmd)` or `` `cmd` ``
+5. **Arithmetic expansion** — `$((1+2))`
+6. **Process substitution** — `<(cmd)`, `>(cmd)` (simultaneous with steps 2-5)
+7. **Word splitting** — based on `$IFS`
+8. **Filename expansion** (globbing) — `*`, `?`, `[...]`
+9. **Quote removal** — always last
+
+Only brace expansion, word splitting, and filename expansion can increase the number of words.
+
+## Brace Expansion
+
+Strictly textual — performed before other expansions. No syntactic interpretation.
+
+```bash
+echo a{d,c,b}e           # ade ace abe
+echo {1..5}              # 1 2 3 4 5
+echo {a..f}              # a b c d e f
+echo {01..05}            # 01 02 03 04 05 (zero-padded)
+echo {1..10..2}          # 1 3 5 7 9 (step)
+mkdir /usr/local/src/{old,new,dist}
+```
+
+`${` inhibits brace expansion — it's treated as parameter expansion instead.
+
+## Tilde Expansion
+
+| Syntax | Result |
+|--------|--------|
+| `~` | `$HOME` |
+| `~/foo` | `$HOME/foo` |
+| `~fred/foo` | Home directory of user `fred` |
+| `~+/foo` | `$PWD/foo` |
+| `~-/foo` | `${OLDPWD}/foo` |
+| `~N` | Directory stack entry (like `dirs +N`) |
+| `~-N` | Directory stack entry (like `dirs -N`) |
+
+Results are treated as quoted — no word splitting or filename expansion on tilde-expanded values.
+
+## Parameter Expansion
+
+### Basic
+
+```bash
+${parameter}              # Value of parameter
+${#parameter}             # Length in characters
+${#array[@]}              # Number of array elements
+${!prefix*}               # Variable names beginning with prefix
+${!name[@]}               # Array indices/keys
+${!parameter}             # Indirect expansion — expand value as new parameter name
+```
+
+### Default Values
+
+| Syntax | Meaning |
+|--------|---------|
+| `${parameter:-word}` | Use `word` if unset or null |
+| `${parameter:=word}` | Assign `word` if unset or null |
+| `${parameter:+word}` | Use `word` if set and non-null |
+| `${parameter:?word}` | Error if unset or null |
+
+With colon: tests for both existence and non-null. Without colon: tests only for existence.
+
+### Substring
+
+```bash
+${parameter:offset}           # From offset to end
+${parameter:offset:length}   # Length characters from offset
+${parameter: -7}              # Last 7 characters (space before - is required)
+```
+
+### Pattern Removal
+
+```bash
+${parameter#pattern}    # Remove shortest match from beginning
+${parameter##pattern}   # Remove longest match from beginning
+${parameter%pattern}    # Remove shortest match from end
+${parameter%%pattern}   # Remove longest match from end
+```
+
+Patterns use glob syntax (not regex). Common uses:
+
+```bash
+file=archive.tar.gz
+${file#*.}              # tar.gz
+${file##*.}             # gz
+${file%.*}              # archive.tar
+${file%%.*}             # archive
+```
+
+### Pattern Substitution
+
+```bash
+${parameter/pattern/string}     # Replace first match
+${parameter//pattern/string}    # Replace all matches
+${parameter/#pattern/string}    # Match at beginning only
+${parameter/%pattern/string}    # Match at end only
+```
+
+If `string` is null, matches are deleted. `&` in the replacement refers to the matched text (escape with `\&`).
+
+### Case Modification
+
+```bash
+${parameter^pattern}    # Uppercase first matching char
+${parameter^^pattern}   # Uppercase all matching chars
+${parameter,pattern}    # Lowercase first matching char
+${parameter,,pattern}   # Lowercase all matching chars
+```
+
+Without pattern, all characters are matched:
+
+```bash
+${var^}                 # First char to uppercase
+${var^^}                # All to uppercase
+${var,}                 # First char to lowercase
+${var,,}                # All to lowercase
+```
+
+### Parameter Transformation
+
+```bash
+${parameter@U}          # Uppercase
+${parameter@u}          # Uppercase first character
+${parameter@L}          # Lowercase
+${parameter@Q}          # Quote for reuse as input
+${parameter@E}          # Expand backslash escapes
+${parameter@P}          # Expand as prompt string
+${parameter@A}          # Assignment statement
+${parameter@K}          # Quoted key-value pairs
+${parameter@a}          # Attribute flags
+${parameter@k}          # Separate words
+```
+
+## Command Substitution
+
+```bash
+$(command)              # Standard form
+`command`               # Deprecated backtick form
+$(< file)               # Faster than $(cat file)
+${| command; }          # Execute in current environment, capture to REPLY
+```
+
+- Executes in subshell environment (except `${| ...; }` form)
+- Trailing newlines deleted
+- Within double quotes: no word splitting or filename expansion
+
+## Arithmetic Expansion
+
+```bash
+$(( expression ))
+```
+
+- Tokens undergo parameter expansion, command substitution, quote removal
+- Empty strings evaluate to 0
+- May be nested
+- Supports: `+`, `-`, `*`, `/`, `%`, `**`, `++`, `--`, `==`, `!=`, `<`, `>`, `<=`, `>=`, `&&`, `||`, `!`, `~`, `&`, `|`, `^`, `<<`, `>>`, assignment operators, ternary `?:`
+
+## Process Substitution
+
+```bash
+<(list)                 # Read output of list from file
+>(list)                 # Write input to list via file
+```
+
+- Process runs asynchronously
+- Filename passed as argument to the current command
+- Requires FIFOs or `/dev/fd` support
+
+## Word Splitting
+
+After parameter expansion, command substitution, and arithmetic expansion, bash scans results for word splitting — **only if not within double quotes**.
+
+### IFS (Internal Field Separator)
+
+| IFS State | Behavior |
+|-----------|----------|
+| Unset | Defaults to `<space><tab><newline>` |
+| Null (`IFS=''`) | No word splitting occurs |
+| Set | Each character is a delimiter |
+
+**IFS whitespace** (space, tab, newline) is always treated as whitespace regardless of IFS value:
+- Leading/trailing IFS whitespace is removed
+- Sequences of IFS whitespace delimiters are treated as a single delimiter
+- Non-whitespace IFS characters delimit individually
+
+**Null arguments:**
+- Explicit null arguments (`""` or `''`) are retained
+- Unquoted implicit null arguments (from unset parameters) are removed
+
+### Special Parameter Splitting
+
+| Syntax | Behavior |
+|--------|----------|
+| `"$*"` | Single word: `"$1c$2c..."` where `c` is first IFS character |
+| `"$@"` | Separate words: `"$1" "$2" ...` |
+| `$*` (unquoted) | Subject to word splitting and globbing |
+| `$@` (unquoted) | Subject to word splitting and globbing |
+
+### Arrays
+
+```bash
+"${array[@]}"           # Each element as separate word
+"${array[*]}"           # Single word with IFS separator
+```
+
+## Filename Expansion (Globbing)
+
+After word splitting, words containing `*`, `?`, or `[` (that are not quoted) are treated as patterns.
+
+| Pattern | Meaning |
+|---------|---------|
+| `*` | Any string |
+| `?` | Any single character |
+| `[abc]` | Character class |
+| `[!abc]` or `[^abc]` | Negated character class |
+| `[[:class:]]` | POSIX character class (`alnum`, `alpha`, `digit`, `lower`, `upper`, etc.) |
+
+### Glob Options
+
+| Option | Effect |
+|--------|--------|
+| `nullglob` | Remove unmatched patterns (instead of keeping literal) |
+| `failglob` | Error if no matches |
+| `nocaseglob` | Case-insensitive matching |
+| `dotglob` | Match files starting with `.` |
+| `globstar` | `**` matches directories recursively |
+| `extglob` | Extended patterns: `?(pattern)`, `*(pattern)`, `+(pattern)`, `@(pattern)`, `!(pattern)` |
+
+### FIGNORE
+
+The `FIGNORE` variable filters filename completions:
+
+```bash
+export FIGNORE=".bak:~:.old:.swp"   # Colon-separated suffixes to ignore
+```
+
+### GLOBIGNORE
+
+Colon-separated patterns to exclude from glob matches. Setting `GLOBIGNORE` implicitly enables `dotglob`.
+
+## Special Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `$*` | All positional parameters, IFS-joined |
+| `$@` | All positional parameters, separate words |
+| `$#` | Number of positional parameters |
+| `$?` | Exit status of most recent command |
+| `$-` | Current option flags |
+| `$$` | Process ID of shell |
+| `$!` | Process ID of most recent background job |
+| `$0` | Name of shell or shell script |
+| `$_` | Last argument of previous command (at shell start, absolute path of shell) |
+
+## Arrays
+
+### Declaration
+
+```bash
+declare -a name          # Indexed array
+declare -A name          # Associative array
+name=(value1 value2)     # Compound assignment
+name=([key]=value)       # With subscripts
+name+=(value)            # Append
+```
+
+### Referencing
+
+```bash
+${name[subscript]}       # Single element
+${name[@]}               # All elements (separate words)
+${name[*]}               # All elements (single word)
+${#name[@]}              # Number of elements
+${!name[@]}              # Array indices/keys
+```
+
+Negative indices count from end (`-1` = last element).
+
+## Quoting in Completion Functions
+
+### COMP_WORDBREAKS and Completion
+
+`COMP_WORDBREAKS` (default: `" \t\n\"'@><=;|&(:`) determines how Readline splits the command line into words for completion. This creates problems:
+
+- `--option=value` is split at `=`, so `$2` is only `value`
+- `user@host:port` is split at `@` and `:`
+- `File::Basename` is split at `:`
+
+### Reassembling Words
+
+The bash-completion project provides helpers:
+
+```bash
+# Reassemble words excluding specified characters from word breaks
+_comp__reassemble_words : =   # Reassemble on : and =
+
+# Get current word at cursor position
+_comp__get_cword_at_cursor : =  # Handles wordbreak chars
+```
+
+### Dequoting in Completion Functions
+
+When a completion function receives the current word, it may contain shell quoting. The bash-completion project provides:
+
+```bash
+# Safely expand a quoted word
+_comp_dequote "$cur"     # Result in REPLY
+
+# Shell-quote a word for COMPREPLY
+_comp_quote "$value"    # Result in REPLY
+```
+
+### Quoting and COMPREPLY
+
+When `complete -o noquote` is used (as carapace does), the completion function is responsible for proper quoting of COMPREPLY entries. When `complete -o filenames` is used, Readline handles quoting automatically.
+
+### The `-o filenames` Option
+
+Tells Readline that completions are filenames. Readline then:
+- Adds `/` suffix to directory names
+- Quotes special characters
+- Suppresses trailing space for directories (when `mark-directories` is on)
+
+### The `-o noquote` Option
+
+Tells Readline not to quote completions. The completion function must handle quoting itself. This is used by external completion frameworks (like carapace) that manage their own quoting.
+
+### The `-o fullquote` Option
+
+Tells Readline to quote all completed words, even if they are not filenames.
+
+## References
+
+- [GNU Bash Manual: Quoting](https://www.gnu.org/software/bash/manual/html_node/Quoting.html)
+- [GNU Bash Manual: Shell Expansions](https://www.gnu.org/software/bash/manual/html_node/Shell-Expansions.html)
+- [GNU Bash Manual: Shell Parameter Expansion](https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html)
+- [GNU Bash Manual: Word Splitting](https://www.gnu.org/software/bash/manual/html_node/Word-Splitting.html)
+- [GNU Bash Manual: Filename Expansion](https://www.gnu.org/software/bash/manual/html_node/Filename-Expansion.html)
+- [GNU Bash Manual: Special Parameters](https://www.gnu.org/software/bash/manual/html_node/Special-Parameters.html)
+- [GNU Bash Manual: Arrays](https://www.gnu.org/software/bash/manual/html_node/Arrays.html)
+
+## Related Skills
+
+- **references/completion.md** — how quoting affects COMP_WORDBREAKS and completion functions
+- **references/readline.md** — how Readline handles quoting during completion display

--- a/skills/bash/references/readline.md
+++ b/skills/bash/references/readline.md
@@ -1,0 +1,375 @@
+# Bash Readline
+
+In-depth reference for the GNU Readline library as used by bash — key bindings, variables, editing modes, macros, and how Readline controls the completion display.
+
+## How Readline Works
+
+Readline is the line-editing library that bash uses for interactive input. It sits between the user and the terminal:
+
+1. **Initialization** — reads `~/.inputrc` (or `$INPUTRC`) for key bindings and variable settings
+2. **Character input** — reads characters from the terminal, interprets key sequences, maps them to editing commands
+3. **Buffer management** — text is stored in an internal buffer; characters are inserted at the cursor position
+4. **Re-reading config** — `C-x C-r` re-reads the init file to incorporate changes
+
+## The .inputrc File
+
+### File Locations
+
+| Location | Priority |
+|----------|----------|
+| `$INPUTRC` | If set, used instead of default |
+| `~/.inputrc` | Default user config |
+| `/etc/inputrc` | Fallback if user file doesn't exist |
+
+### Syntax
+
+```
+# Comment lines
+set variable value           # Set a Readline variable
+keyname: function-name       # Bind key to Readline function
+"keyseq": function-name      # Bind key sequence to function
+"keyseq": "macro text"       # Bind key sequence to macro
+$include /path/to/file       # Include another init file
+$if condition                 # Conditional construct
+$else
+$endif
+```
+
+### Conditional Constructs
+
+| Construct | Purpose |
+|-----------|---------|
+| `$if mode=emacs` | Test editing mode (emacs/vi) |
+| `$if term=xterm` | Test terminal type (matches full name or prefix) |
+| `$if application=Bash` | Test application name |
+| `$if version >= 8.0` | Test Readline version (supports `=`, `==`, `!=`, `<=`, `>=`, `<`, `>`) |
+| `$if variable == value` | Test Readline variable equality |
+| `$else` | Execute if test fails |
+| `$endif` | Close conditional block |
+| `$include /path/file` | Include another init file |
+
+### Key Binding Syntax
+
+**Keyname format:**
+```
+Control-u: universal-argument
+Meta-Rubout: backward-kill-word
+```
+
+**String format (for key sequences):**
+```
+"\C-x\C-r": re-read-init-file
+"\e[11~": "Function Key 1"
+```
+
+**Escape sequences:**
+
+| Sequence | Meaning |
+|----------|---------|
+| `\C-` | Control prefix |
+| `\M-` | Meta prefix |
+| `\e` | Escape character |
+| `\\` | Backslash |
+| `\"` | Double quote |
+| `\'` | Single quote |
+| `\a` | Bell |
+| `\b` | Backspace |
+| `\d` | Delete |
+| `\f` | Form feed |
+| `\n` | Newline |
+| `\r` | Carriage return |
+| `\t` | Tab |
+| `\v` | Vertical tab |
+| `\nnn` | Octal character value (1-3 digits) |
+| `\xHH` | Hexadecimal character value |
+
+## The `bind` Builtin
+
+```bash
+bind [-m keymap] [-lsvSVX]
+bind [-m keymap] -f filename
+bind [-m keymap] -x keyseq:shell-command
+bind [-m keymap] keyseq:function-name
+bind [-m keymap] keyseq:readline-command
+bind [-p|-P] [readline-command]
+bind [-q function]
+bind [-u function]
+bind [-r keyseq]
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `-m keymap` | Use specified keymap for subsequent bindings |
+| `-l` | List names of all Readline functions |
+| `-p` / `-P` | Display bindings in reusable format |
+| `-s` / `-S` | Display macro bindings |
+| `-v` / `-V` | Display variable names and values |
+| `-f filename` | Read bindings from file |
+| `-q function` | Show key sequences invoking function |
+| `-u function` | Unbind all keys for function |
+| `-r keyseq` | Remove binding for key sequence |
+| `-x keyseq:shell-command` | Execute shell command when keyseq entered |
+| `-X` | List key sequences bound to shell commands via `-x` |
+
+### Variables Available to `bind -x` Shell Commands
+
+| Variable | Description |
+|----------|-------------|
+| `READLINE_LINE` | Contents of Readline line buffer |
+| `READLINE_POINT` | Current insertion point position |
+| `READLINE_MARK` | Saved insertion point (mark) |
+| `READLINE_ARGUMENT` | Numeric argument supplied by user |
+
+These can be read and modified — changing `READLINE_LINE` or `READLINE_POINT` updates the line buffer.
+
+### Keymaps
+
+| Keymap | When Active |
+|--------|-------------|
+| `emacs` | Emacs mode default |
+| `emacs-standard` | Emacs mode (same as `emacs`) |
+| `emacs-meta` | Meta key prefix in emacs mode |
+| `emacs-ctlx` | `C-x` prefix in emacs mode |
+| `vi` | Vi mode default |
+| `vi-command` | Vi command mode |
+| `vi-move` | Vi movement mode (same as `vi-command`) |
+| `vi-insert` | Vi insertion mode |
+
+## Editing Modes
+
+### Emacs Mode (Default)
+
+Standard Emacs-style key bindings. Control keys operate on characters, Meta keys on words.
+
+**Essential commands:**
+
+| Key | Command |
+|-----|---------|
+| `C-a` | Move to start of line |
+| `C-e` | Move to end of line |
+| `C-f` | Move forward one character |
+| `C-b` | Move backward one character |
+| `M-f` | Move forward one word |
+| `M-b` | Move backward one word |
+| `C-l` | Clear screen, reprint line |
+| `C-k` | Kill to end of line |
+| `M-d` | Kill word forward |
+| `M-DEL` | Kill word backward |
+| `C-w` | Kill backward to whitespace |
+| `C-y` | Yank last killed text |
+| `M-y` | Rotate kill-ring and yank |
+| `C-_` | Undo |
+| `C-x C-r` | Re-read init file |
+
+### Vi Mode
+
+Enable with `set -o vi` or `set editing-mode vi` in `.inputrc`.
+
+- Starts in **insertion mode** (you can type immediately)
+- Press `ESC` to enter **command mode**
+- Standard vi movement: `h`/`l` (char), `b`/`w` (word), `0`/`$` (line)
+- `i`/`a` to re-enter insertion mode
+- `dd` to kill line, `p` to yank
+
+## Completion Commands
+
+| Key | Command | Description |
+|-----|---------|-------------|
+| `TAB` | `complete` | Attempt completion on text before point |
+| `M-?` | `possible-completions` | List possible completions |
+| `M-*` | `insert-completions` | Insert all completions separated by space |
+| `M-/` | `complete-filename` | Filename completion |
+| `M-~` | `complete-username` | Username completion |
+| `M-$` | `complete-variable` | Shell variable completion |
+| `M-@` | `complete-hostname` | Hostname completion |
+| `M-!` | `complete-command` | Command name completion |
+| `M-TAB` | `dynamic-complete-history` | Complete from history |
+| `M-{` | `complete-into-braces` | Insert completions in brace format |
+| (unbind) | `menu-complete` | Replace word with first match; cycle on repeat |
+| (unbind) | `menu-complete-backward` | Cycle backward through matches |
+
+### Menu Completion
+
+To make TAB cycle through completions instead of showing all:
+
+```bash
+# In .inputrc
+TAB: menu-complete
+"\e[Z": menu-complete-backward
+
+# Or via bind
+bind 'TAB: menu-complete'
+bind '"\e[Z": menu-complete-backward'
+```
+
+## Readline Variables
+
+### Completion Variables
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `completion-ignore-case` | `off` | Case-insensitive filename matching |
+| `completion-map-case` | `off` | Treat `-` and `_` as equivalent (with `completion-ignore-case`) |
+| `colored-stats` | `off` | Use LS_COLORS to indicate file types in completion lists |
+| `visible-stats` | `off` | Append file-type indicator character to completions |
+| `show-all-if-ambiguous` | `off` | List all completions immediately on first TAB |
+| `show-all-if-unmodified` | `off` | List completions immediately if no unique prefix |
+| `completion-prefix-display-length` | `0` | Ellipsize common prefix longer than N; hidden files use `___` |
+| `colored-completion-prefix` | `off` | Display common prefix in different color (uses LS_COLORS) |
+| `mark-symlinked-directories` | `off` | Append `/` to symlinks pointing to directories |
+| `mark-directories` | `on` | Append `/` to completed directory names |
+| `match-hidden-files` | `on` | Match dotfiles during completion |
+| `completion-query-items` | `100` | Prompt before showing more than N completions |
+| `completion-display-width` | `-1` | Screen columns for match display; `0` = one per line |
+| `page-completions` | `on` | Use internal pager for completion lists |
+| `print-completions-horizontally` | `off` | Sort horizontally instead of vertically |
+| `skip-completed-text` | `off` | Don't duplicate text after cursor on mid-word completion |
+| `menu-complete-display-prefix` | `off` | Show common prefix before cycling menu completions |
+| `disable-completion` | `off` | Disable completion entirely |
+| `expand-tilde` | `off` | Perform tilde expansion during completion |
+
+### Display Variables
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `bell-style` | `audible` | `none`, `visible`, or `audible` |
+| `horizontal-scroll-mode` | `off` | Scroll horizontally vs. line wrapping |
+| `enable-bracketed-paste` | `on` | Handle pasted text as single string |
+| `blink-matching-paren` | `off` | Briefly move cursor to matching opening paren |
+
+### Editing Mode Variables
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `editing-mode` | `emacs` | `emacs` or `vi` |
+| `keymap` | `emacs` | Current keymap |
+| `show-mode-in-prompt` | `off` | Show editing mode indicator in prompt |
+| `emacs-mode-string` | `@` | String for emacs mode indicator |
+| `vi-ins-mode-string` | `(ins)` | String for vi insertion mode |
+| `vi-cmd-mode-string` | `(cmd)` | String for vi command mode |
+
+### Input/Output Variables
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `input-meta` | `off` | Enable eight-bit input (synonym: `meta-flag`) |
+| `output-meta` | `off` | Display eighth-bit characters directly |
+| `convert-meta` | `on` | Convert eighth-bit chars to meta-prefixed sequences |
+| `enable-meta-key` | `on` | Attempt to enable meta modifier key |
+| `enable-keypad` | `off` | Enable application keypad mode |
+
+### History Variables
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `history-preserve-point` | `off` | Keep cursor position when navigating history |
+| `history-size` | `HISTSIZE` | Maximum history entries (0 = disable, <0 = unlimited) |
+| `revert-all-at-newline` | `off` | Undo all history changes before accept-line |
+| `mark-modified-lines` | `off` | Display `*` before modified history lines |
+| `isearch-terminators` | `ESC C-j` | Characters that terminate incremental search |
+| `search-ignore-case` | `off` | Case-insensitive history search |
+
+### Other Variables
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `comment-begin` | `"#"` | String for `insert-comment` command |
+| `keyseq-timeout` | `500` | Milliseconds to wait for ambiguous key sequence |
+| `bind-tty-special-chars` | `on` | Bind kernel terminal control characters |
+| `echo-control-characters` | `on` | Echo characters for keyboard-generated signals |
+| `active-region-start-color` | standout | Terminal escape before active region text |
+| `active-region-end-color` | restore | Terminal escape to restore after active region |
+| `enable-active-region` | `on` | Enable region highlighting |
+
+## Keyboard Macros
+
+| Key | Command |
+|-----|---------|
+| `C-x (` | `start-kbd-macro` — begin saving |
+| `C-x )` | `end-kbd-macro` — stop saving |
+| `C-x e` | `call-last-kbd-macro` — replay last macro |
+| (unbound) | `print-last-kbd-macro` — print in inputrc format |
+
+### Macro Examples
+
+```bash
+# In .inputrc
+"\C-xp": "PATH=${PATH}\e\C-e\C-a\ef\C-f"   # Insert PATH expansion
+"\C-x\"": "\"\"\C-b"                          # Insert "" and move between
+"\C-o": "> output"                            # Insert literal text
+```
+
+## Active Region
+
+Readline supports highlighting a region between point (cursor) and mark:
+
+- `C-@` or `C-x C-x` — set mark at current position
+- `enable-active-region` — controls whether highlighting is active
+- `active-region-start-color` / `active-region-end-color` — terminal escape sequences for highlighting
+
+## Word Boundaries and Tokenization
+
+Readline determines word boundaries for:
+
+1. **Movement commands** (`M-f`, `M-b`) — words are composed of alphanumeric characters and underscores
+2. **Completion tokenization** — when completing, Readline identifies the "word being completed" by finding boundaries around the cursor position
+3. **COMP_WORDBREAKS** — characters that split words for completion purposes (default: `" \t\n\"'@><=;|&(:`)
+
+### Completion Type Detection
+
+Readline checks what the word begins with to determine completion type:
+
+| Prefix | Completion Type |
+|--------|----------------|
+| `$` | Variable completion |
+| `~` | Username/home directory completion |
+| `@` | Hostname completion |
+| (other) | Command, filename, or programmable completion |
+
+## Sample .inputrc
+
+```
+# Editing mode
+set editing-mode emacs
+
+# Completion behavior
+set completion-ignore-case on
+set show-all-if-ambiguous on
+set visible-stats on
+set colored-stats on
+set colored-completion-prefix on
+set completion-prefix-display-length 2
+set bell-style visible
+set mark-symlinked-directories on
+
+# Pager
+set page-completions on
+set completion-query-items 200
+
+# Key bindings
+$if mode=emacs
+"\M-[D": backward-char
+"\M-[C": forward-char
+$endif
+
+$if Bash
+"\C-xp": "PATH=${PATH}\e\C-e\C-a\ef\C-f"
+$endif
+```
+
+## References
+
+- [GNU Bash Manual: Readline Interaction](https://www.gnu.org/software/bash/manual/html_node/Readline-Interaction.html)
+- [GNU Bash Manual: Readline Init File](https://www.gnu.org/software/bash/manual/html_node/Readline-Init-File.html)
+- [GNU Bash Manual: Readline Init File Syntax](https://www.gnu.org/software/bash/manual/html_node/Readline-Init-File-Syntax.html)
+- [GNU Bash Manual: Bindable Readline Commands](https://www.gnu.org/software/bash/manual/html_node/Bindable-Readline-Commands.html)
+- [GNU Bash Manual: Commands For Completion](https://www.gnu.org/software/bash/manual/html_node/Commands-For-Completion.html)
+- [GNU Bash Manual: Readline vi Mode](https://www.gnu.org/software/bash/manual/html_node/Readline-vi-Mode.html)
+- [GNU Bash Manual: Sample Init File](https://www.gnu.org/software/bash/manual/html_node/Sample-Init-File.html)
+
+## Related Skills
+
+- **references/completion.md** — how Readline variables interact with programmable completion
+- **references/quoting-expansion.md** — how Readline tokenizes and quotes during completion

--- a/skills/bash/references/startup.md
+++ b/skills/bash/references/startup.md
@@ -1,0 +1,294 @@
+# Bash Startup Files and Configuration
+
+In-depth reference for which files bash reads at startup, how shell options work, and where to install completions.
+
+## Startup File Decision Flow
+
+### Interactive Login Shell (or `--login` flag)
+
+1. `/etc/profile` — system-wide (first)
+2. **First found** of:
+   - `~/.bash_profile`
+   - `~/.bash_login`
+   - `~/.profile`
+3. On exit: `~/.bash_logout` (if it exists)
+
+### Interactive Non-Login Shell
+
+- Reads `~/.bashrc`
+- `--norc` disables this
+- `--rcfile file` uses a custom file instead of `~/.bashrc`
+
+### Non-Interactive Shell (script execution)
+
+- Looks for `BASH_ENV` environment variable
+- If set, reads and executes that file: `if [ -n "$BASH_ENV" ]; then . "$BASH_ENV"; fi`
+- PATH is **not** used to locate the file
+
+### Invoked as `sh`
+
+- **Login shell**: Reads `/etc/profile` then `~/.profile`
+- **Interactive `sh`**: Looks for `ENV` variable and reads that file
+- **Non-interactive `sh`**: Does not read any startup files
+- `--rcfile` has no effect when invoked as `sh`
+
+### POSIX Mode (`--posix` flag)
+
+- Interactive shells expand `ENV` variable and read that file
+- No other startup files are read
+
+### Remote Shell Daemon (rshd/sshd)
+
+- Reads `~/.bashrc` if it exists
+- Does **not** read if invoked as `sh`
+
+### Elevated Privileges (unequal UID/GID)
+
+- No startup files are read unless `-p` flag is supplied
+- Shell functions from environment are ignored
+- Certain environment variables are ignored: `SHELLOPTS`, `BASHOPTS`, `CDPATH`, `GLOBIGNORE`
+
+## File Purposes
+
+| File | When Read | Typical Contents |
+|------|-----------|------------------|
+| `/etc/profile` | Login shells | System-wide PATH, umask, environment |
+| `~/.bash_profile` | Bash login shells | User login initializations, source `.bashrc` |
+| `~/.bash_login` | Bash login (if no `.bash_profile`) | Fallback for `.bash_profile` |
+| `~/.profile` | sh login / Bash (if no `.bash_profile`/`.bash_login`) | Bourne-compatible environment |
+| `~/.bashrc` | Interactive non-login shells | Aliases, functions, shell options, completions |
+| `/etc/bash.bashrc` | Interactive shells (Debian-specific) | System-wide interactive settings |
+| `~/.bash_logout` | Login shell exit | Cleanup, logout messages |
+
+## Common Patterns
+
+### Typical `~/.bash_profile`
+
+```bash
+# Source .bashrc for interactive shells
+if [ -f ~/.bashrc ]; then
+    . ~/.bashrc
+fi
+
+# Login-specific initializations
+export PATH="$HOME/bin:$PATH"
+```
+
+This pattern ensures `.bashrc` is sourced for both login and non-login interactive shells.
+
+### Typical `~/.bashrc`
+
+```bash
+# Exit if not interactive
+[[ $- != *i* ]] && return
+
+# Environment
+export PATH="$HOME/bin:$PATH"
+export EDITOR=vim
+
+# Aliases
+alias ll='ls -la'
+alias la='ls -A'
+
+# Shell options
+shopt -s autocd
+shopt -s cdspell
+shopt -s checkwinsize
+shopt -s histappend
+
+# History
+export HISTSIZE=10000
+export HISTCONTROL=ignoredups:erasedups
+export HISTIGNORE="ls:cd:exit"
+
+# Prompt
+PS1='\u@\h:\w\$ '
+
+# Completions
+if [ -f /usr/share/bash-completion/bash_completion ]; then
+    . /usr/share/bash-completion/bash_completion
+elif [ -f /etc/bash_completion ]; then
+    . /etc/bash_completion
+fi
+```
+
+## Pitfalls
+
+1. **Order matters**: If `~/.bash_profile` exists, `~/.profile` is **ignored**
+2. **Missing `.bashrc` sourcing**: Login shells won't get aliases/functions unless `.bash_profile` sources `.bashrc`
+3. **BASH_ENV vs ENV**: `BASH_ENV` is for non-interactive bash; `ENV` is for POSIX mode and `sh` invocation
+4. **Scripts ignore interactive configs**: Non-interactive shells only read `BASH_ENV`, not `.bashrc`
+5. **SSH sessions**: SSH typically invokes login shells (`.bash_profile`), but `ssh host command` is non-interactive
+6. **Error handling**: If a startup file exists but cannot be read, bash reports an error
+
+## Shell Options
+
+### `set` Options
+
+| Option | Flag | Effect |
+|--------|------|--------|
+| `allexport` | `-a` | Mark variables for export on assignment |
+| `braceexpand` | `-B` | Enable brace expansion |
+| `emacs` | | Use emacs editing mode |
+| `errexit` | `-e` | Exit on command failure |
+| `errtrace` | `-E` | ERR trap inherited by functions |
+| `functrace` | `-T` | DEBUG/RETURN traps inherited by functions |
+| `hashall` | `-h` | Hash commands on first lookup |
+| `histexpand` | `-H` | Enable `!` history expansion |
+| `history` | | Enable command history |
+| `ignoreeof` | | Don't exit on `^D` (require `exit`) |
+| `keyword` | `-k` | All assignment statements in environment |
+| `monitor` | `-m` | Enable job control |
+| `noclobber` | `-C` | Don't overwrite existing files with `>` |
+| `noexec` | `-n` | Read commands but don't execute |
+| `noglob` | `-f` | Disable filename expansion |
+| `notify` | `-b` | Report terminated background jobs immediately |
+| `nounset` | `-u` | Error on unset variable reference |
+| `onecmd` | `-t` | Exit after one command |
+| `physical` | `-P` | Don't resolve symlinks in `cd`/`pwd` |
+| `pipefail` | | Pipeline fails if any command fails |
+| `posix` | | POSIX mode |
+| `privileged` | `-p` | Don't process startup files |
+| `verbose` | `-v` | Echo input lines |
+| `vi` | | Use vi editing mode |
+| `xtrace` | `-x` | Trace command execution |
+
+### `shopt` Options
+
+| Option | Default | Effect |
+|--------|---------|--------|
+| `autocd` | off | `cd` by typing directory name |
+| `cdable_vars` | off | `cd` to variable name if directory doesn't exist |
+| `cdspell` | off | Auto-correct minor `cd` typos |
+| `checkwinsize` | on | Update LINES/COLUMNS after each command |
+| `cmdhist` | on | Save multi-line commands as single history entry |
+| `compat31` | off | Compatibility with bash 3.1 |
+| `compat32` | off | Compatibility with bash 3.2 |
+| `compat40` | off | Compatibility with bash 4.0 |
+| `dirspell` | off | Auto-correct directory name typos in completion |
+| `dotglob` | off | Include dotfiles in glob expansion |
+| `execfail` | off | Non-interactive shell doesn't exit on exec failure |
+| `expand_aliases` | on (interactive) | Expand aliases |
+| `extdebug` | off | Extended debugging (affects DEBUG trap) |
+| `extglob` | off | Extended glob patterns (`?()`, `*()`, `+()`, `@()`, `!()`) |
+| `extquote` | on | Allow `$'...'` and `$"..."` in expansions |
+| `failglob` | off | Error if glob pattern doesn't match |
+| `force_fignore` | on | FIGNORE applies even if only match |
+| `globasciiranges` | on | Glob ranges use ASCII order |
+| `globstar` | off | `**` matches directories recursively |
+| `gnu_errfmt` | off | GNU-style error messages |
+| `histappend` | off | Append to (not overwrite) history file |
+| `histreedit` | off | Re-edit failed history expansion |
+| `histverify` | off | Don't execute history expansion immediately |
+| `hostcomplete` | on | Complete hostnames containing `@` |
+| `huponexit` | off | Send SIGHUP to all jobs on login shell exit |
+| `inherit_errexit` | off | Command substitution inherits `errexit` |
+| `interactive_comments` | on | Allow `#` comments in interactive shell |
+| `lastpipe` | off | Last pipeline element runs in current shell (no job control) |
+| `lithist` | off | Save multi-line commands with embedded newlines |
+| `localvar_inherit` | off | Local variables inherit value from outer scope |
+| `login_shell` | (set by shell) | Shell is a login shell |
+| `mailwarn` | off | Warn if mail file was accessed since last check |
+| `no_empty_cmd_completion` | off | Don't try completion on empty line |
+| `nocaseglob` | off | Case-insensitive glob matching |
+| `nocasematch` | off | Case-insensitive pattern matching in `case`/`[[` |
+| `nullglob` | off | Unmatched globs expand to nothing |
+| `progcomp` | on | Enable programmable completion |
+| `progcomp_alias` | off | Try compspec for alias expansion result |
+| `promptvars` | on | Expand variables in prompt strings |
+| `restricted_shell` | (set by shell) | Shell is restricted |
+| `shift_verbose` | off | `shift` prints error when shifting past end |
+| `sourcepath` | on | `source` uses PATH to find files |
+| `xpg_echo` | off | `echo` expands escape sequences by default |
+
+## Completion Installation Locations
+
+### Where to Install Completions
+
+| Location | Scope | Priority |
+|----------|-------|----------|
+| `~/.local/share/bash-completion/completions/` | User | 1 (highest) |
+| `$BASH_COMPLETION_USER_DIR/completions/` | User | 1 |
+| `/usr/share/bash-completion/completions/` | System | 2 |
+| `<prefix>/share/bash-completion/completions/` | Package | 3 |
+| `$XDG_DATA_DIRS/bash-completion/completions/` | System | 4 |
+| `/etc/bash_completion.d/` | Legacy | 5 (lowest) |
+
+### When Completions Are Loaded
+
+- **bash-completion package**: Loaded on demand via `_completion_loader` (default compspec with `-D`)
+- **Sourced in `.bashrc`**: Loaded at shell startup
+- **Sourced in `.bash_profile`**: Loaded at login
+
+### Recommended Installation
+
+For user-specific completions:
+
+```bash
+mkdir -p ~/.local/share/bash-completion/completions
+cp mytool-completion.bash ~/.local/share/bash-completion/completions/mytool
+```
+
+For system-wide:
+
+```bash
+cp mytool-completion.bash /usr/share/bash-completion/completions/mytool
+```
+
+The file should be named after the command (no `.bash` extension required, but both work).
+
+## Environment Variables
+
+### Key Bash Variables
+
+| Variable | Description |
+|----------|-------------|
+| `BASH_ENV` | File to source for non-interactive shells |
+| `BASH_XTRACEFD` | File descriptor for `set -x` output |
+| `CDPATH` | Search path for `cd` |
+| `FIGNORE` | Suffixes to ignore in completion (`:.` separated) |
+| `GLOBIGNORE` | Patterns to exclude from globbing |
+| `HISTFILE` | History file path (default: `~/.bash_history`) |
+| `HISTSIZE` | Max history entries in memory |
+| `HISTFILESIZE` | Max history entries on disk |
+| `HISTCONTROL` | History filtering: `ignoredups`, `ignorespace`, `erasedups`, `ignoreboth` |
+| `HISTIGNORE` | Patterns to exclude from history |
+| `HISTTIMEFORMAT` | Timestamp format for history entries |
+| `HOSTFILE` | File for hostname completion (like `/etc/hosts`) |
+| `INPUTRC` | Override default `.inputrc` location |
+| `LANG` / `LC_ALL` / `LC_*` | Locale settings |
+| `MAIL` / `MAILPATH` | Mail checking paths |
+| `PROMPT_COMMAND` | Command(s) to run before displaying PS1 |
+| `PROMPT_DIRTRIM` | Trim directory depth in `\w` prompt |
+| `PS1` / `PS2` / `PS3` / `PS4` | Prompt strings |
+| `SHELLOPTS` | Enabled `set` options (colon-separated) |
+| `TIMEFORMAT` | Format for `time` output |
+| `TMOUT` | Auto-logout timeout (seconds, 0 = disabled) |
+
+### Carapace-Relevant Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `CARAPACE_LOG` | Enable carapace debug logging |
+| `CARAPACE_SANDBOX` | JSON mock context (set by sandbox tests) |
+| `CARAPACE_LENIENT` | Allow unknown flags |
+| `CARAPACE_MATCH` | Set to `CASE_INSENSITIVE` for case-insensitive matching |
+| `CARAPACE_NOSPACE` | Additional nospace suffixes |
+| `CARAPACE_UNFILTERED` | Skip prefix filtering |
+| `CARAPACE_EXPERIMENTAL` | Enable experimental features |
+| `CARAPACE_HIDDEN` | Show hidden commands/flags |
+| `CARAPACE_TOOLTIP` | Enable tooltip style |
+| `CARAPACE_DESCRIPTION_LENGTH` | Max description length (default 80) |
+| `NO_COLOR` / `CLICOLOR=0` | Disable colors |
+
+## References
+
+- [GNU Bash Manual: Bash Startup Files](https://www.gnu.org/software/bash/manual/html_node/Bash-Startup-Files.html)
+- [GNU Bash Manual: The Set Builtin](https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html)
+- [GNU Bash Manual: The Shopt Builtin](https://www.gnu.org/software/bash/manual/html_node/The-Shopt-Builtin.html)
+- [GNU Bash Manual: Bash Variables](https://www.gnu.org/software/bash/manual/html_node/Bash-Variables.html)
+
+## Related Skills
+
+- **references/completion.md** — where to install completions and how they're loaded
+- **references/execution.md** — how startup files affect the execution environment

--- a/skills/carapace-dev/SKILL.md
+++ b/skills/carapace-dev/SKILL.md
@@ -68,4 +68,5 @@ Load the reference that matches your task. When in doubt, load multiple referenc
 
 ## Cross-Project References
 
-For user-facing topics (integrating carapace into a CLI, writing specs, macros, setup, choices), use the **carapace** skill (in the carapace-bin repo).
+- For user-facing topics (integrating carapace into a CLI, writing specs, macros, setup, choices), use the **carapace** skill (in the carapace-bin repo).
+- For in-depth bash shell knowledge (programmable completion, Readline, quoting/expansion, execution model, startup files), use the **bash** skill (in this repo).


### PR DESCRIPTION
Covers programmable completion (complete/compgen/compopt, COMP_* variables,
bash-completion helpers, dynamic loading), Readline (.inputrc, bind, keymaps,
completion display variables), quoting and expansion (all quoting mechanisms,
expansion order, word splitting, COMP_WORDBREAKS in completion), execution
model (subshells, pipelines, job control, signals, traps, PROMPT_COMMAND),
and startup files (login/non-login decision flow, shell options, completion
installation locations).

Assisted-by: Crush:glm-5.1
