### PR TITLE
Document zsh case-insensitive matching setup

### DIFF
--- a/docs/src/development/shells/zsh.md
+++ b/docs/src/development/shells/zsh.md
@@ -1,1 +1,22 @@
 # Zsh
+
+## Case-insensitive matching
+
+`CARAPACE_MATCH=CASE_INSENSITIVE` makes carapace return case-insensitive matches,
+but zsh still filters the candidates it receives. Configure zsh's completion
+matcher as well:
+
+```zsh
+zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}'
+```
+
+For example, add the matcher alongside the carapace completion script:
+
+```zsh
+export CARAPACE_MATCH=CASE_INSENSITIVE
+zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}'
+source <(command _carapace)
+```
+
+Without the `zstyle` matcher, zsh can filter out candidates that carapace
+already matched.


### PR DESCRIPTION
This documents the zsh-side matcher setup needed when using `CARAPACE_MATCH=CASE_INSENSITIVE`.

What changed:
- Added a zsh shell docs section with the `zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}'` setting.
- Included a short example showing it alongside `CARAPACE_MATCH=CASE_INSENSITIVE`.

Why:
In #1061, carapace can return case-insensitive candidates while zsh still filters those candidates unless its completion matcher is configured too. This adds the documentation note mentioned in the maintainer comment.

Closes #1061.

Checked:
- `git diff --check`
- `go build ./...`
- `go test -run TestSnippet -count=1`
- `go test ./... -run '^$'`
- `gofmt -d -s .`
- `golangci-lint run`

Note:
- `go test ./...` did not complete in this local macOS environment. A clean-baseline run timed out after 10m in `TestContext` while `pkg/ps.DetermineShell()` was in the Darwin process lookup path. This PR only changes docs.
- `mdbook build` was not run because `mdbook` is not installed locally.
