### PR TITLE
zsh: moved noprefix check up

### DIFF
--- a/example/cmd/_test/zsh.sh
+++ b/example/cmd/_test/zsh.sh
@@ -19,6 +19,7 @@ function _example_completion {
   zstyle ":completion:${curcontext}:*" list-colors "${zstyle}"
   zstyle ":completion:${curcontext}:*" group-name ''
   [ -z "$message" ] || _message -r "${message}"
+  [[ "${noprefix}" = "true" ]] && compstate[insert]=menu
   
   local block tag displays values displaysArr valuesArr
   while IFS=$'\002' read -r -d $'\002' block; do
@@ -29,8 +30,6 @@ function _example_completion {
   
     [[ ${#valuesArr[@]} -gt 1 ]] && _describe -t "${tag}" "${tag}" displaysArr valuesArr -Q -S ''
   done <<<"${data}"
-
-  [[ "${noprefix}" = "true" ]] && compstate[insert]=menu
 }
 compquote '' 2>/dev/null && _example_completion
 compdef _example_completion example

--- a/internal/shell/zsh/snippet.go
+++ b/internal/shell/zsh/snippet.go
@@ -31,6 +31,7 @@ function _%[1]v_completion {
   zstyle ":completion:${curcontext}:*" list-colors "${zstyle}"
   zstyle ":completion:${curcontext}:*" group-name ''
   [ -z "$message" ] || _message -r "${message}"
+  [[ "${noprefix}" = "true" ]] && compstate[insert]=menu
   
   local block tag displays values displaysArr valuesArr
   while IFS=$'\002' read -r -d $'\002' block; do
@@ -41,8 +42,6 @@ function _%[1]v_completion {
   
     [[ ${#valuesArr[@]} -gt 1 ]] && _describe -t "${tag}" "${tag}" displaysArr valuesArr -Q -S ''
   done <<<"${data}"
-
-  [[ "${noprefix}" = "true" ]] && compstate[insert]=menu
 }
 compquote '' 2>/dev/null && _%[1]v_completion
 compdef _%[1]v_completion %[1]v`, cmd.Name(), uid.Executable())


### PR DESCRIPTION
when `false`, the whole function is deemed failed.
which breaks the completion menu (last state).
