### PR TITLE
Fix xonsh multi-completer snippet using wrong format argument index

### DIFF
--- a/example-multi/cmd/_test/xonsh.py
+++ b/example-multi/cmd/_test/xonsh.py
@@ -4,7 +4,7 @@ from xonsh.completers.tools import contextual_command_completer
 @contextual_command_completer
 def _carapace_identify_completer(context):
     """carapace multi-completer"""
-    if context.command not in [example-multi]:
+    if context.command not in ['example-multi', 'identify', 'convert']:
         return
 
     from json import loads

--- a/internal/shell/xonsh/snippet.go
+++ b/internal/shell/xonsh/snippet.go
@@ -25,7 +25,7 @@ from xonsh.completers.tools import contextual_command_completer
 @contextual_command_completer
 def _carapace_%[1]v_completer(context):
     """carapace multi-completer"""
-    if context.command not in [%v]:
+    if context.command not in [%[3]v]:
         return
 
     from json import loads


### PR DESCRIPTION
The `%v` on line 28 of SnippetMulti picked up arg index 2 (the
executable path) instead of index 3 (the command names list), causing
Python to evaluate `example-multi` as an expression and crash with
NameError.

Assisted-by: Crush:glm-5.1
