### PR TITLE
Fix multi-completer shell function named after first subcommand instead of executable

### DIFF
--- a/carapace.go
+++ b/carapace.go
@@ -42,18 +42,14 @@ func WithSubcommands(cmds ...*cobra.Command) Option {
 		e.subcommandNames = names
 
 		if e.defaultName == "" {
-			if len(cmds) > 0 {
-				e.defaultName = cmds[0].Name()
-			} else {
-				e.defaultName = exe
-			}
+			e.defaultName = exe
 		}
 	}
 }
 
-// WithDefault sets the default subcommand for multi-completer routing
-// when os.Args[4] is not a known subcommand name.
-// Defaults to the first subcommand. No-op without WithSubcommands.
+// WithDefault sets the name used for the shell completer function
+// in multi-completer snippets (e.g. _carapace_<name>_completer).
+// Defaults to the executable name. No-op without WithSubcommands.
 func WithDefault(name string) Option {
 	return func(e *entry) {
 		e.defaultName = name

--- a/carapace_test.go
+++ b/carapace_test.go
@@ -354,6 +354,20 @@ func TestGenWithDefault(t *testing.T) {
 	}
 }
 
+func TestGenWithSubcommandsDefaultName(t *testing.T) {
+	sub1 := &cobra.Command{Use: "sub1"}
+	sub2 := &cobra.Command{Use: "sub2"}
+	root := &cobra.Command{Use: "root"}
+
+	Gen(root, WithSubcommands(sub1, sub2))
+
+	entry := storage.get(root)
+	exe := uid.Executable()
+	if entry.defaultName != exe {
+		t.Errorf("expected defaultName '%v' (executable), got '%v'", exe, entry.defaultName)
+	}
+}
+
 func TestGenWithDefaultNoop(t *testing.T) {
 	cmd := &cobra.Command{Use: "test"}
 	Gen(cmd, WithDefault("sub1"))

--- a/example-multi/cmd/_test/bash-ble.sh
+++ b/example-multi/cmd/_test/bash-ble.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-_carapace_identify_completer() {
+_example-multi_completer() {
   export COMP_LINE
   export COMP_POINT
   export COMP_TYPE
@@ -27,7 +27,7 @@ _carapace_identify_completer() {
 
 
 
-_identify_completion_ble() {
+_example-multi_completer_ble() {
   if [[ ${BLE_ATTACHED-} ]]; then
     [[ :$comp_type: == *:auto:* ]] && return
 
@@ -46,9 +46,9 @@ _identify_completion_ble() {
       [ ! -z "$cand" ] && ble/complete/cand/yield mandb "${cand%$'\t'*}" "${cand##*$'\t'}"
     done
   else
-    complete -F _carapace_identify_completer "example-multi" "identify" "convert"
+    complete -F _example-multi_completer "example-multi" "identify" "convert"
   fi
 }
 
-complete -F _identify_completion_ble "example-multi" "identify" "convert"
+complete -F _example-multi_completer_ble "example-multi" "identify" "convert"
 

--- a/example-multi/cmd/_test/bash.sh
+++ b/example-multi/cmd/_test/bash.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-_carapace_identify_completer() {
+_example-multi_completer() {
   export COMP_LINE
   export COMP_POINT
   export COMP_TYPE
@@ -25,5 +25,5 @@ _carapace_identify_completer() {
   [[ "${COMPREPLY[*]}" == "" ]] && COMPREPLY=() # fix for mapfile creating a non-empty array from empty command output
 }
 
-complete -o noquote -F _carapace_identify_completer "example-multi" "identify" "convert"
+complete -o noquote -F _example-multi_completer "example-multi" "identify" "convert"
 

--- a/example-multi/cmd/_test/fish.fish
+++ b/example-multi/cmd/_test/fish.fish
@@ -1,4 +1,4 @@
-function _carapace_identify_completer
+function _example-multi_completer
   set --local data
   IFS='' set data (echo (commandline -cp)'' | sed "s/ \$/ ''/" | xargs example-multi $argv[1] _carapace fish 2>/dev/null)
   if [ $status -eq 1 ]
@@ -11,9 +11,9 @@ function _carapace_identify_completer
 end
 
 complete -e "example-multi"
-complete -c "example-multi" -f -a '(_carapace_identify_completer "example-multi")' -r
+complete -c "example-multi" -f -a '(_example-multi_completer "example-multi")' -r
 complete -e "identify"
-complete -c "identify" -f -a '(_carapace_identify_completer "identify")' -r
+complete -c "identify" -f -a '(_example-multi_completer "identify")' -r
 complete -e "convert"
-complete -c "convert" -f -a '(_carapace_identify_completer "convert")' -r
+complete -c "convert" -f -a '(_example-multi_completer "convert")' -r
 

--- a/example-multi/cmd/_test/nushell.nu
+++ b/example-multi/cmd/_test/nushell.nu
@@ -1,4 +1,4 @@
-let carapace_identify_completer = {|spans|
+let example-multi_completer = {|spans|
     example-multi $spans.0 _carapace nushell ...$spans | from json
 }
 
@@ -7,7 +7,7 @@ $current.completions = ($current.completions | default {} external)
 $current.completions.external = ($current.completions.external
 ||| default true enable
 |||# backwards compatible workaround for default, see nushell #15654
-||| upsert completer { if $in == null { $carapace_identify_completer } else { $in } })
+||| upsert completer { if $in == null { $example-multi_completer } else { $in } })
 
 $env.config = $current
 

--- a/example-multi/cmd/_test/oil.sh
+++ b/example-multi/cmd/_test/oil.sh
@@ -1,5 +1,5 @@
 #!/bin/osh
-_carapace_identify_completer() {
+_example-multi_completer() {
   local command="${COMP_WORDS[0]}"
   local compline="${COMP_LINE:0:${COMP_POINT}}"
   local IFS=$'\n'
@@ -10,5 +10,5 @@ _carapace_identify_completer() {
   [[ ${#COMPREPLY[@]} -eq 1 ]] && COMPREPLY=(${COMPREPLY[@]%$'\001'})
 }
 
-complete -F _carapace_identify_completer "example-multi" "identify" "convert"
+complete -F _example-multi_completer "example-multi" "identify" "convert"
 

--- a/example-multi/cmd/_test/powershell.ps1
+++ b/example-multi/cmd/_test/powershell.ps1
@@ -1,7 +1,7 @@
 using namespace System.Management.Automation
 using namespace System.Management.Automation.Language
 
-$_carapace_identify_completer = {
+$_example-multi_completer = {
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingInvokeExpression", "", Scope="Function", Target="*")]
     param($wordToComplete, $commandAst, $cursorPosition)
     $commandElements = $commandAst.CommandElements
@@ -43,7 +43,7 @@ $_carapace_identify_completer = {
     $completions
 }
 
-Register-ArgumentCompleter -Native -ScriptBlock $_carapace_identify_completer -CommandName 'example-multi' # 'example-multi.exe'
-Register-ArgumentCompleter -Native -ScriptBlock $_carapace_identify_completer -CommandName 'identify' # 'identify.exe'
-Register-ArgumentCompleter -Native -ScriptBlock $_carapace_identify_completer -CommandName 'convert' # 'convert.exe'
+Register-ArgumentCompleter -Native -ScriptBlock $_example-multi_completer -CommandName 'example-multi' # 'example-multi.exe'
+Register-ArgumentCompleter -Native -ScriptBlock $_example-multi_completer -CommandName 'identify' # 'identify.exe'
+Register-ArgumentCompleter -Native -ScriptBlock $_example-multi_completer -CommandName 'convert' # 'convert.exe'
 

--- a/example-multi/cmd/_test/xonsh.py
+++ b/example-multi/cmd/_test/xonsh.py
@@ -2,7 +2,7 @@ from xonsh.completers.completer import add_one_completer
 from xonsh.completers.tools import contextual_command_completer
 
 @contextual_command_completer
-def _carapace_identify_completer(context):
+def _example-multi_completer(context):
     """carapace multi-completer"""
     if context.command not in ['example-multi', 'identify', 'convert']:
         return
@@ -26,5 +26,5 @@ def _carapace_identify_completer(context):
         result = {RichCompletion(context.prefix, display=context.prefix, description='', prefix_len=len(context.raw_prefix), append_closing_quote=False)}
     return result
 
-add_one_completer('carapace_identify', _carapace_identify_completer, 'start')
+add_one_completer('example-multi', _example-multi_completer, 'start')
 

--- a/example-multi/cmd/_test/zsh.sh
+++ b/example-multi/cmd/_test/zsh.sh
@@ -1,5 +1,5 @@
 #compdef "example-multi" "identify" "convert"
-function _carapace_identify_completer {
+function _example-multi_completer {
   local command="$(basename $words[1])"
   local compline=${words[@]:0:$CURRENT}
   local IFS=$'\n'
@@ -32,6 +32,6 @@ function _carapace_identify_completer {
     [[ ${#valuesArr[@]} -gt 1 ]] && _describe -t "${tag}" "${tag}" displaysArr valuesArr -Q -S ''
   done <<<"${data}"
 }
-compquote '' 2>/dev/null && _carapace_identify_completer
-compdef _carapace_identify_completer "example-multi" "identify" "convert"
+compquote '' 2>/dev/null && _example-multi_completer
+compdef _example-multi_completer "example-multi" "identify" "convert"
 

--- a/internal/shell/bash/snippet.go
+++ b/internal/shell/bash/snippet.go
@@ -20,7 +20,7 @@ func SnippetMulti(names []string, defaultName string, snippetFuncs string) strin
 		quoted[i] = fmt.Sprintf("%q", name)
 	}
 	return fmt.Sprintf(`#!/bin/bash
-%[4]v_carapace_%[1]v_completer() {
+%[4]v_%[1]v_completer() {
   export COMP_LINE
   export COMP_POINT
   export COMP_TYPE
@@ -46,7 +46,7 @@ func SnippetMulti(names []string, defaultName string, snippetFuncs string) strin
   [[ "${COMPREPLY[*]}" == "" ]] && COMPREPLY=() # fix for mapfile creating a non-empty array from empty command output
 }
 
-complete -o noquote -F _carapace_%[1]v_completer %[3]v
+complete -o noquote -F _%[1]v_completer %[3]v
 `, defaultName, uid.Executable(), strings.Join(quoted, " "), snippetFuncs)
 }
 

--- a/internal/shell/bash_ble/snippet.go
+++ b/internal/shell/bash_ble/snippet.go
@@ -24,7 +24,7 @@ func SnippetMulti(names []string, defaultName string, snippetFuncs string) strin
 	quotedJoined := strings.Join(quoteAll(names), " ")
 
 	return fmt.Sprintf(`%v
-_%[2]v_completion_ble() {
+_%[2]v_completer_ble() {
   if [[ ${BLE_ATTACHED-} ]]; then
     [[ :$comp_type: == *:auto:* ]] && return
 
@@ -43,11 +43,11 @@ _%[2]v_completion_ble() {
       [ ! -z "$cand" ] && ble/complete/cand/yield mandb "${cand%%$'\t'*}" "${cand##*$'\t'}"
     done
   else
-    complete -F _carapace_%[2]v_completer %[4]v
+    complete -F _%[2]v_completer %[4]v
   fi
 }
 
-complete -F _%[2]v_completion_ble %[4]v
+complete -F _%[2]v_completer_ble %[4]v
 `, bashSnip, defaultName, uid.Executable(), quotedJoined)
 }
 

--- a/internal/shell/fish/snippet.go
+++ b/internal/shell/fish/snippet.go
@@ -20,10 +20,10 @@ func SnippetMulti(names []string, defaultName string, snippetFuncs string) strin
 	for _, name := range names {
 		complete = append(complete,
 			fmt.Sprintf(`complete -e %q`, name),
-			fmt.Sprintf(`complete -c %[2]q -f -a '(_carapace_%[1]v_completer %[2]q)' -r`, defaultName, name),
+			fmt.Sprintf(`complete -c %[2]q -f -a '(_%[1]v_completer %[2]q)' -r`, defaultName, name),
 		)
 	}
-	return fmt.Sprintf(`%[4]vfunction _carapace_%[1]v_completer
+	return fmt.Sprintf(`%[4]vfunction _%[1]v_completer
   set --local data
   IFS='' set data (echo (commandline -cp)'' | sed "s/ \$/ ''/" | xargs %[2]v $argv[1] _carapace fish 2>/dev/null)
   if [ $status -eq 1 ]

--- a/internal/shell/multi/snippet_test.go
+++ b/internal/shell/multi/snippet_test.go
@@ -14,7 +14,7 @@ func TestSnippetBash(t *testing.T) {
 	if !strings.Contains(s, "#!/bin/bash") {
 		t.Error("missing bash shebang")
 	}
-	if !strings.Contains(s, `_carapace_sub1_completer`) {
+	if !strings.Contains(s, `_sub1_completer`) {
 		t.Error("missing completer function name")
 	}
 	if !strings.Contains(s, `"${command}"`) {
@@ -37,7 +37,7 @@ func TestSnippetZsh(t *testing.T) {
 	if !strings.Contains(s, "#compdef") {
 		t.Error("missing compdef header")
 	}
-	if !strings.Contains(s, `_carapace_sub1_completer`) {
+	if !strings.Contains(s, `_sub1_completer`) {
 		t.Error("missing completer function name")
 	}
 	if !strings.Contains(s, `"${command}"`) {
@@ -51,7 +51,7 @@ func TestSnippetFish(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if !strings.Contains(s, `function _carapace_sub1_completer`) {
+	if !strings.Contains(s, `function _sub1_completer`) {
 		t.Error("missing completer function name")
 	}
 	if !strings.Contains(s, `$argv[1]`) {
@@ -86,7 +86,7 @@ func TestSnippetNushell(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if !strings.Contains(s, `carapace_sub1_completer`) {
+	if !strings.Contains(s, `sub1_completer`) {
 		t.Error("missing completer name")
 	}
 	if !strings.Contains(s, `$spans.0`) {
@@ -103,7 +103,7 @@ func TestSnippetPowershell(t *testing.T) {
 	if !strings.Contains(s, "System.Management.Automation") {
 		t.Error("missing namespace")
 	}
-	if !strings.Contains(s, `$_carapace_sub1_completer`) {
+	if !strings.Contains(s, `$_sub1_completer`) {
 		t.Error("missing completer variable")
 	}
 	if !strings.Contains(s, `($elems[0] -replace ('\.exe$', ''))`) {
@@ -134,7 +134,7 @@ func TestSnippetOil(t *testing.T) {
 	if !strings.Contains(s, "#!/bin/osh") {
 		t.Error("missing osh shebang")
 	}
-	if !strings.Contains(s, `_carapace_sub1_completer`) {
+	if !strings.Contains(s, `_sub1_completer`) {
 		t.Error("missing completer function name")
 	}
 }

--- a/internal/shell/nushell/snippet.go
+++ b/internal/shell/nushell/snippet.go
@@ -14,7 +14,7 @@ func Snippet(cmd *cobra.Command) string {
 
 // SnippetMulti creates a multi-completer nushell completion script.
 func SnippetMulti(names []string, defaultName string, snippetFuncs string) string {
-	return fmt.Sprintf(`%[4]vlet carapace_%[1]v_completer = {|spans|
+	return fmt.Sprintf(`%[4]vlet %[1]v_completer = {|spans|
     %[2]v $spans.0 _carapace nushell ...$spans | from json
 }
 
@@ -23,7 +23,7 @@ $current.completions = ($current.completions | default {} external)
 $current.completions.external = ($current.completions.external
 ||| default true enable
 |||# backwards compatible workaround for default, see nushell #15654
-||| upsert completer { if $in == null { $carapace_%[1]v_completer } else { $in } })
+||| upsert completer { if $in == null { $%[1]v_completer } else { $in } })
 
 $env.config = $current
 `, defaultName, uid.Executable(), "", snippetFuncs)
@@ -35,7 +35,7 @@ $env.config = $current
 // When false, only the minimal completer function is generated (standalone mode).
 func SnippetSingle(command string, explicitCommand bool) string {
 	if explicitCommand {
-		return fmt.Sprintf(`let carapace_%[2]v_completer = {|spans|
+		return fmt.Sprintf(`let %[2]v_completer = {|spans|
     %[1]v %[2]v _carapace nushell ...$spans | from json
 }
 
@@ -44,7 +44,7 @@ $current.completions = ($current.completions | default {} external)
 $current.completions.external = ($current.completions.external
 ||| default true enable
 |||# backwards compatible workaround for default, see nushell #15654
-||| upsert completer { if $in == null { $carapace_%[2]v_completer } else { $in } })
+||| upsert completer { if $in == null { $%[2]v_completer } else { $in } })
 
 $env.config = $current
 `, uid.Executable(), command)

--- a/internal/shell/oil/snippet.go
+++ b/internal/shell/oil/snippet.go
@@ -20,7 +20,7 @@ func SnippetMulti(names []string, defaultName string, snippetFuncs string) strin
 		quoted[i] = fmt.Sprintf("%q", name)
 	}
 	return fmt.Sprintf(`#!/bin/osh
-%[4]v_carapace_%[1]v_completer() {
+%[4]v_%[1]v_completer() {
   local command="${COMP_WORDS[0]}"
   local compline="${COMP_LINE:0:${COMP_POINT}}"
   local IFS=$'\n'
@@ -31,7 +31,7 @@ func SnippetMulti(names []string, defaultName string, snippetFuncs string) strin
   [[ ${#COMPREPLY[@]} -eq 1 ]] && COMPREPLY=(${COMPREPLY[@]%%$'\001'})
 }
 
-complete -F _carapace_%[1]v_completer %[3]v
+complete -F _%[1]v_completer %[3]v
 `, defaultName, uid.Executable(), strings.Join(quoted, " "), snippetFuncs)
 }
 

--- a/internal/shell/powershell/snippet.go
+++ b/internal/shell/powershell/snippet.go
@@ -109,7 +109,7 @@ $_%[2]v_completion = {
 const snippetMulti = `using namespace System.Management.Automation
 using namespace System.Management.Automation.Language
 %[4]v
-$_carapace_%[1]v_completer = {
+$_%[1]v_completer = {
     [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingInvokeExpression", "", Scope="Function", Target="*")]
     param($wordToComplete, $commandAst, $cursorPosition)
     $commandElements = $commandAst.CommandElements
@@ -167,7 +167,7 @@ func SnippetMulti(names []string, defaultName string, snippetFuncs string) strin
 		if runtime.GOOS == "windows" {
 			prefix = ""
 		}
-		complete[i] = fmt.Sprintf(`Register-ArgumentCompleter -Native -ScriptBlock $_carapace_%v_completer -CommandName '%v'%v'%v.exe'`, defaultName, name, prefix, name)
+		complete[i] = fmt.Sprintf(`Register-ArgumentCompleter -Native -ScriptBlock $_%v_completer -CommandName '%v'%v'%v.exe'`, defaultName, name, prefix, name)
 	}
 	return fmt.Sprintf(snippetMulti, defaultName, uid.Executable(), strings.Join(complete, "\n"), snippetFuncs)
 }

--- a/internal/shell/xonsh/snippet.go
+++ b/internal/shell/xonsh/snippet.go
@@ -23,7 +23,7 @@ func SnippetMulti(names []string, defaultName string, snippetFuncs string) strin
 from xonsh.completers.tools import contextual_command_completer
 
 @contextual_command_completer
-def _carapace_%[1]v_completer(context):
+def _%[1]v_completer(context):
     """carapace multi-completer"""
     if context.command not in [%[3]v]:
         return
@@ -47,7 +47,7 @@ def _carapace_%[1]v_completer(context):
         result = {RichCompletion(context.prefix, display=context.prefix, description='', prefix_len=len(context.raw_prefix), append_closing_quote=False)}
     return result
 
-add_one_completer('carapace_%[1]v', _carapace_%[1]v_completer, 'start')
+add_one_completer('%[1]v', _%[1]v_completer, 'start')
 `, defaultName, uid.Executable(), strings.Join(complete, ", "), "", snippetFuncs)
 }
 

--- a/internal/shell/zsh/snippet.go
+++ b/internal/shell/zsh/snippet.go
@@ -21,7 +21,7 @@ func SnippetMulti(names []string, defaultName string, snippetFuncs string) strin
 		quoted[i] = fmt.Sprintf("%q", name)
 	}
 	return fmt.Sprintf(`#compdef %[3]v
-%[4]vfunction _carapace_%[1]v_completer {
+%[4]vfunction _%[1]v_completer {
   local command="$(basename $words[1])"
   local compline=${words[@]:0:$CURRENT}
   local IFS=$'\n'
@@ -54,8 +54,8 @@ func SnippetMulti(names []string, defaultName string, snippetFuncs string) strin
     [[ ${#valuesArr[@]} -gt 1 ]] && _describe -t "${tag}" "${tag}" displaysArr valuesArr -Q -S ''
   done <<<"${data}"
 }
-compquote '' 2>/dev/null && _carapace_%[1]v_completer
-compdef _carapace_%[1]v_completer %[3]v
+compquote '' 2>/dev/null && _%[1]v_completer
+compdef _%[1]v_completer %[3]v
 `, defaultName, uid.Executable(), strings.Join(quoted, " "), snippetFuncs)
 }
 


### PR DESCRIPTION
WithSubcommands defaulted defaultName to cmds[0].Name(), causing all
shell snippets to name their completer function after the first
subcommand (e.g. _carapace_identify_completer). Since the function
handles all commands, it should be named after the executable
(e.g. _carapace_example-multi_completer).

Assisted-by: Crush:glm-5.1
