### PR TITLE
Fix zsh multi-completer snippet using quoted command names in compdef

### DIFF
--- a/example-multi/cmd/_test/zsh.sh
+++ b/example-multi/cmd/_test/zsh.sh
@@ -1,4 +1,4 @@
-#compdef "example-multi" "identify" "convert"
+#compdef example-multi identify convert
 function _example-multi_completer {
   local command="$(basename $words[1])"
   local compline=${words[@]:0:$CURRENT}
@@ -33,5 +33,5 @@ function _example-multi_completer {
   done <<<"${data}"
 }
 compquote '' 2>/dev/null && _example-multi_completer
-compdef _example-multi_completer "example-multi" "identify" "convert"
+compdef _example-multi_completer example-multi identify convert
 

--- a/internal/shell/zsh/snippet.go
+++ b/internal/shell/zsh/snippet.go
@@ -16,10 +16,6 @@ func Snippet(cmd *cobra.Command) string {
 
 // SnippetMulti creates a multi-completer zsh completion script.
 func SnippetMulti(names []string, defaultName string, snippetFuncs string) string {
-	quoted := make([]string, len(names))
-	for i, name := range names {
-		quoted[i] = fmt.Sprintf("%q", name)
-	}
 	return fmt.Sprintf(`#compdef %[3]v
 %[4]vfunction _%[1]v_completer {
   local command="$(basename $words[1])"
@@ -56,7 +52,7 @@ func SnippetMulti(names []string, defaultName string, snippetFuncs string) strin
 }
 compquote '' 2>/dev/null && _%[1]v_completer
 compdef _%[1]v_completer %[3]v
-`, defaultName, uid.Executable(), strings.Join(quoted, " "), snippetFuncs)
+`, defaultName, uid.Executable(), strings.Join(names, " "), snippetFuncs)
 }
 
 // SnippetSingle creates a single-command zsh completion script.


### PR DESCRIPTION
The #compdef directive and compdef builtin expect unquoted command
names, but SnippetMulti was using fmt.Sprintf("%q", name) which
produced double-quoted strings like "identify". This caused compinit
to register the completer for a command literally named "identify"
(with quotes), so it never matched the actual command and fell back
to whatever completer was already registered.

Assisted-by: Crush:glm-5.1
