### PR TITLE
fix snippet hyphenated names

### DIFF
--- a/internal/shell/cmd_clink/snippet.go
+++ b/internal/shell/cmd_clink/snippet.go
@@ -2,10 +2,15 @@ package cmd_clink
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/carapace-sh/carapace/pkg/uid"
 	"github.com/spf13/cobra"
 )
+
+func sanitize(s string) string {
+	return strings.ReplaceAll(s, "-", "__")
+}
 
 func Snippet(cmd *cobra.Command) string {
 	result := fmt.Sprintf(`local function %[1]s_completion(word, word_index, line_state, match_builder)
@@ -13,7 +18,7 @@ func Snippet(cmd *cobra.Command) string {
     match_builder:setvolatile()
     os.setenv('CARAPACE_COMPLINE', line_state:getline():sub(1, line_state:getcursor()))
 
-    local file, pclose = io.popenyield('%[2]s _carapace cmd-clink %[1]s')
+    local file, pclose = io.popenyield('%[3]s _carapace cmd-clink %[2]s')
 
     if not file then
         return false
@@ -42,7 +47,7 @@ func Snippet(cmd *cobra.Command) string {
     return not match_builder:isempty()
 end
 
-clink.argmatcher(50, '%[1]s', '%[1]s.exe'):addarg({nowordbreakchars="'`+"`"+`=+;,", %[1]s_completion}):loop(1)
-`, cmd.Name(), uid.Executable())
+clink.argmatcher(50, '%[2]s', '%[2]s.exe'):addarg({nowordbreakchars="'`+"`"+`=+;,", %[1]s_completion}):loop(1)
+`, sanitize(cmd.Name()), cmd.Name(), uid.Executable())
 	return result
 }

--- a/internal/shell/multi/snippet_test.go
+++ b/internal/shell/multi/snippet_test.go
@@ -261,3 +261,68 @@ func TestSnippetFuncsForShell(t *testing.T) {
 		t.Error("expected empty for missing shell key")
 	}
 }
+
+func TestSnippetHyphenatedDefaultName(t *testing.T) {
+	names := []string{"example-multi", "sub1"}
+	// PowerShell and xonsh use underscore-prefixed identifiers
+	shells := []string{"powershell", "xonsh"}
+	for _, sh := range shells {
+		s, err := Snippet(sh, names, "example-multi", nil)
+		if err != nil {
+			t.Errorf("%v: %v", sh, err)
+		}
+		if strings.Contains(s, `_example-multi_`) {
+			t.Errorf("%v: hyphenated identifier not sanitized in snippet: %s", sh, s)
+		}
+		if !strings.Contains(s, `_example__multi_`) {
+			t.Errorf("%v: missing sanitized identifier in snippet", sh)
+		}
+		if !strings.Contains(s, `example-multi`) {
+			t.Errorf("%v: missing raw command name in registration", sh)
+		}
+	}
+
+	// nushell uses variable names without underscore prefix
+	s, err := Snippet("nushell", names, "example-multi", nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if strings.Contains(s, `example-multi_completer`) {
+		t.Error("nushell: hyphenated identifier not sanitized")
+	}
+	if !strings.Contains(s, `example__multi_completer`) {
+		t.Error("nushell: missing sanitized identifier")
+	}
+}
+
+func TestSingleSnippetHyphenatedCommand(t *testing.T) {
+	shells := []string{"powershell", "xonsh"}
+	names := []string{"example-multi", "sub1"}
+	for _, sh := range shells {
+		s, err := SingleSnippet(sh, "example-multi", names, "example-multi", nil)
+		if err != nil {
+			t.Errorf("%v: %v", sh, err)
+		}
+		if strings.Contains(s, `_example-multi_`) {
+			t.Errorf("%v: hyphenated identifier not sanitized in single snippet", sh)
+		}
+		if !strings.Contains(s, `_example__multi_`) {
+			t.Errorf("%v: missing sanitized identifier in single snippet", sh)
+		}
+		if !strings.Contains(s, `example-multi`) {
+			t.Errorf("%v: missing raw command name in single snippet", sh)
+		}
+	}
+
+	// nushell uses variable names without underscore prefix
+	s, err := SingleSnippet("nushell", "example-multi", names, "example-multi", nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if strings.Contains(s, `example-multi_completer`) {
+		t.Error("nushell: hyphenated identifier not sanitized")
+	}
+	if !strings.Contains(s, `example__multi_completer`) {
+		t.Error("nushell: missing sanitized identifier")
+	}
+}

--- a/internal/shell/nushell/snippet.go
+++ b/internal/shell/nushell/snippet.go
@@ -2,10 +2,15 @@ package nushell
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/carapace-sh/carapace/pkg/uid"
 	"github.com/spf13/cobra"
 )
+
+func sanitizeName(s string) string {
+	return strings.ReplaceAll(s, "-", "__")
+}
 
 // Snippet creates the nushell completion script.
 func Snippet(cmd *cobra.Command) string {
@@ -26,7 +31,7 @@ $current.completions.external = ($current.completions.external
 ||| upsert completer { if $in == null { $%[1]v_completer } else { $in } })
 
 $env.config = $current
-`, defaultName, uid.Executable(), "", snippetFuncs)
+`, sanitizeName(defaultName), uid.Executable(), "", snippetFuncs)
 }
 
 // SnippetSingle creates a single-command nushell completion script.
@@ -36,7 +41,7 @@ $env.config = $current
 func SnippetSingle(command string, explicitCommand bool) string {
 	if explicitCommand {
 		return fmt.Sprintf(`let %[2]v_completer = {|spans|
-    %[1]v %[2]v _carapace nushell ...$spans | from json
+    %[1]v %[3]v _carapace nushell ...$spans | from json
 }
 
 mut current = (($env | default {} config).config | default {} completions)
@@ -47,10 +52,10 @@ $current.completions.external = ($current.completions.external
 ||| upsert completer { if $in == null { $%[2]v_completer } else { $in } })
 
 $env.config = $current
-`, uid.Executable(), command)
+`, uid.Executable(), sanitizeName(command), command)
 	}
 
 	return fmt.Sprintf(`let %v_completer = {|spans| 
     %v _carapace nushell ...$spans | from json
-}`, command, uid.Executable())
+}`, sanitizeName(command), uid.Executable())
 }

--- a/internal/shell/nushell/snippet.go
+++ b/internal/shell/nushell/snippet.go
@@ -26,9 +26,9 @@ func SnippetMulti(names []string, defaultName string, snippetFuncs string) strin
 mut current = (($env | default {} config).config | default {} completions)
 $current.completions = ($current.completions | default {} external)
 $current.completions.external = ($current.completions.external
-||| default true enable
-|||# backwards compatible workaround for default, see nushell #15654
-||| upsert completer { if $in == null { $%[1]v_completer } else { $in } })
+    | default true enable
+    |# backwards compatible workaround for default, see nushell #15654
+    | upsert completer { if $in == null { $%[1]v_completer } else { $in } })
 
 $env.config = $current
 `, sanitizeName(defaultName), uid.Executable(), "", snippetFuncs)
@@ -47,9 +47,9 @@ func SnippetSingle(command string, explicitCommand bool) string {
 mut current = (($env | default {} config).config | default {} completions)
 $current.completions = ($current.completions | default {} external)
 $current.completions.external = ($current.completions.external
-||| default true enable
-|||# backwards compatible workaround for default, see nushell #15654
-||| upsert completer { if $in == null { $%[2]v_completer } else { $in } })
+    | default true enable
+    |# backwards compatible workaround for default, see nushell #15654
+    | upsert completer { if $in == null { $%[2]v_completer } else { $in } })
 
 $env.config = $current
 `, uid.Executable(), sanitizeName(command), command)

--- a/internal/shell/powershell/snippet.go
+++ b/internal/shell/powershell/snippet.go
@@ -90,9 +90,9 @@ $_%[2]v_completion = {
 
     $completions = @(
       if (!$wordToComplete) {
-        %[1]v %[2]v _carapace powershell $($elems| ForEach-Object {$_}) '' | ConvertFrom-Json | ForEach-Object { [CompletionResult]::new($_.CompletionText, $_.ListItemText.replace('` + "`" + `e[', "` + "`" + `e["), [CompletionResultType]::ParameterValue, $_.ToolTip.replace('` + "`" + `e[', "` + "`" + `e[")) }
+        %[1]v %[3]v _carapace powershell $($elems| ForEach-Object {$_}) '' | ConvertFrom-Json | ForEach-Object { [CompletionResult]::new($_.CompletionText, $_.ListItemText.replace('` + "`" + `e[', "` + "`" + `e["), [CompletionResultType]::ParameterValue, $_.ToolTip.replace('` + "`" + `e[', "` + "`" + `e[")) }
       } else {
-        %[1]v %[2]v _carapace powershell $($elems| ForEach-Object {$_}) | ConvertFrom-Json | ForEach-Object { [CompletionResult]::new($_.CompletionText, $_.ListItemText.replace('` + "`" + `e[', "` + "`" + `e["), [CompletionResultType]::ParameterValue, $_.ToolTip.replace('` + "`" + `e[', "` + "`" + `e[")) }
+        %[1]v %[3]v _carapace powershell $($elems| ForEach-Object {$_}) | ConvertFrom-Json | ForEach-Object { [CompletionResult]::new($_.CompletionText, $_.ListItemText.replace('` + "`" + `e[', "` + "`" + `e["), [CompletionResultType]::ParameterValue, $_.ToolTip.replace('` + "`" + `e[', "` + "`" + `e[")) }
       }
     )
 
@@ -103,7 +103,7 @@ $_%[2]v_completion = {
     $completions
 }
 
-%[3]v
+%[4]v
 `
 
 const snippetMulti = `using namespace System.Management.Automation
@@ -154,6 +154,10 @@ $_%[1]v_completer = {
 %[3]v
 `
 
+func sanitize(s string) string {
+	return strings.ReplaceAll(s, "-", "__")
+}
+
 // Snippet creates the powershell completion script.
 func Snippet(cmd *cobra.Command) string {
 	return SnippetSingle(cmd.Name(), false)
@@ -167,9 +171,9 @@ func SnippetMulti(names []string, defaultName string, snippetFuncs string) strin
 		if runtime.GOOS == "windows" {
 			prefix = ""
 		}
-		complete[i] = fmt.Sprintf(`Register-ArgumentCompleter -Native -ScriptBlock $_%v_completer -CommandName '%v'%v'%v.exe'`, defaultName, name, prefix, name)
+		complete[i] = fmt.Sprintf(`Register-ArgumentCompleter -Native -ScriptBlock $_%v_completer -CommandName '%v'%v'%v.exe'`, sanitize(defaultName), name, prefix, name)
 	}
-	return fmt.Sprintf(snippetMulti, defaultName, uid.Executable(), strings.Join(complete, "\n"), snippetFuncs)
+	return fmt.Sprintf(snippetMulti, sanitize(defaultName), uid.Executable(), strings.Join(complete, "\n"), snippetFuncs)
 }
 
 // SnippetSingle creates a single-command powershell completion script.
@@ -183,15 +187,15 @@ func SnippetSingle(command string, explicitCommand bool) string {
 	}
 
 	if explicitCommand {
-		complete := fmt.Sprintf(`Register-ArgumentCompleter -Native -ScriptBlock $_%v_completion -CommandName '%v'%v'%v.exe'`, command, command, prefix, command)
-		return fmt.Sprintf(snippetMultiSingle, uid.Executable(), command, complete)
+		complete := fmt.Sprintf(`Register-ArgumentCompleter -Native -ScriptBlock $_%v_completion -CommandName '%v'%v'%v.exe'`, sanitize(command), command, prefix, command)
+		return fmt.Sprintf(snippetMultiSingle, uid.Executable(), sanitize(command), command, complete)
 	}
 
 	return fmt.Sprintf(snippetOriginal,
-		command,
+		sanitize(command),
 		uid.Executable(),
 		uid.Executable(),
-		command,
+		sanitize(command),
 		command,
 		prefix,
 		command)

--- a/internal/shell/xonsh/snippet.go
+++ b/internal/shell/xonsh/snippet.go
@@ -48,7 +48,7 @@ def _%[1]v_completer(context):
     return result
 
 add_one_completer('%[1]v', _%[1]v_completer, 'start')
-`, defaultName, uid.Executable(), strings.Join(complete, ", "), "", snippetFuncs)
+`, strings.ReplaceAll(defaultName, "-", "__"), uid.Executable(), strings.Join(complete, ", "), "", snippetFuncs)
 }
 
 // SnippetSingle creates a single-command xonsh completion script.


### PR DESCRIPTION
- **Fix shell snippets breaking with hyphenated command names**
- **Fix nushell snippet using invalid ||| pipe syntax**
