### PR TITLE
Preserve Uid and Tag on static segments in MultiPartsP

### DIFF
--- a/action.go
+++ b/action.go
@@ -208,7 +208,16 @@ func (a Action) MultiPartsP(delimiter string, pattern string, f func(placeholder
 						return invoked.ToA()
 					}))
 				} else {
-					actions = append(actions, ActionStyledValuesDescribed(key, value.Description, value.Style)) // TODO tag,..
+					actions = append(actions, ActionCallback(func(c Context) Action {
+						return Action{rawValues: []common.RawValue{{
+							Value:       key,
+							Display:     key,
+							Description: value.Description,
+							Style:       value.Style,
+							Tag:         value.Tag,
+							Uid:         value.Uid,
+						}}}
+					}))
 				}
 			}
 


### PR DESCRIPTION
Static segments (non-placeholder) were only passing Description and
Style through to the output action, dropping Uid and Tag from the
original raw value. This prevented man page documentation from
resolving for completion values that go through MultiPartsP, such as
git config keys.

Assisted-by: Crush:glm-5.2
