### PR TITLE
docs: add inspect.software health badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![PkgGoDev](https://pkg.go.dev/badge/github.com/carapace-sh/carapace)](https://pkg.go.dev/github.com/carapace-sh/carapace)
 [![documentation](https://img.shields.io/badge/&zwnj;-documentation-blue?logo=gitbook)](https://carapace-sh.github.io/carapace/)
 [![Coverage Status](https://coveralls.io/repos/github/carapace-sh/carapace/badge.svg?branch=master)](https://coveralls.io/github/carapace-sh/carapace?branch=master)
+[![inspect.software](https://raw.githubusercontent.com/inspect-software/badges/main/v1/c/carapace-sh/carapace.svg)](https://inspect.software/software/carapace-sh/carapace)
 
 Command argument completion generator for [cobra].
 


### PR DESCRIPTION
This PR adds the [inspect.software](https://inspect.software) health badge to the README.

**Why this PR?**
Your project ranks in the upper rating bands of our open-source health index (which measures maintainability, responsiveness, and security). This badge makes that standing objectively visible to your users. Our index is a free public good, and scores cannot be bought.

**Technical details:**
- **No tracking:** Static SVG served via GitHub's CDN. No JavaScript, no third-party tracking.
- **No maintenance:** The badge updates automatically after every inspection.
- **Transparent:** Links directly to [your full report](https://inspect.software/software/carapace-sh/carapace), based on our open [methodology](https://inspect.software/methodology).

If you prefer to keep your README minimal, feel free to close this PR without replying. Your report will remain publicly available and up-to-date either way.
